### PR TITLE
Issue #111 Fix - Disables "Ban Communism" and "Anti-Communist Raids" if France bans communism through event.

### DIFF
--- a/common/decisions/political_decisions.txt
+++ b/common/decisions/political_decisions.txt
@@ -1651,11 +1651,17 @@ political_actions = {
 
     	visible = {
 			NOT = { has_government = communism }
+			NOT = { 
+				AND = {
+					tag = FRA
+					has_idea = FRA_communism_banned
+					} 
+			}
 		}
 
 		available = {
-            communism > 0.1
-        }
+          			  communism > 0.1
+        			}
 	
 		modifier = {
 			communism_drift = -0.05
@@ -1788,6 +1794,12 @@ political_actions = {
 		visible = {
 			NOT = { has_government = communism }
 			communism > 0
+			NOT = { 
+				AND = {
+					tag = FRA
+					has_idea = FRA_communism_banned
+					} 
+			}
 		}
 
 		remove_trigger = {


### PR DESCRIPTION
Fixes Issue #111 by preventing the ban communism and anti-communist raid decisions from appearing if France has banned communism through an event. Unfortunately, I could not find the event that bans communism in Belgium (but I could add a similar condition if someone could point it out to me)