### PR TITLE
Issue #98 Add Blendheim Tooltip

### DIFF
--- a/common/national_focus/finland.txt
+++ b/common/national_focus/finland.txt
@@ -3007,7 +3007,12 @@ focus_tree = {
 				technology = basic_battleship
 				technology = improved_battleship
 				technology = advanced_battleship
-				technology = heavy_battleship
+				technology = 
+				
+				
+				
+				
+				_battleship
 				technology = heavy_battleship2
 			}
 		}
@@ -3590,6 +3595,7 @@ focus_tree = {
 		}
 		
 		completion_reward ={
+		custom_effect_tooltip = FIN_bristol_research
 			add_equipment_to_stockpile = {
             type = heavy_fighter_equipment_1 #type of equipment, from file
             amount = 75 #amount


### PR DESCRIPTION
Adds a tooltip which informs players that the Blendheims will not appear in the effect until the UK researches heavy fighters