### PR TITLE
#95 Updating Leader Portraits - Honduras

### DIFF
--- a/history/countries/HON - Honduras.txt
+++ b/history/countries/HON - Honduras.txt
@@ -118,3 +118,30 @@ create_country_leader = {
 		elections_allowed = yes
 	}
 }
+
+create_corps_commander = {
+	name = "Abel Villanueva Villacorta"
+	portrait_path = "gfx/leaders/South America/Portrait_South_America_Generic_land_1.dds"
+	traits = { trait_cautious }
+	skill = 3
+    attack_skill = 2
+    defense_skill = 2
+    planning_skill = 3
+    logistics_skill = 3
+}
+create_corps_commander = {
+	name = "Mateo Ortega"
+	portrait_path = "gfx/leaders/South America/Portrait_South_America_Generic_land_2.dds"
+	traits = {jungle_rat }
+	skill = 2
+    attack_skill = 1
+    defense_skill = 2
+    planning_skill = 2
+    logistics_skill = 2
+}
+create_navy_leader = {
+	name = "Williams Calderon"
+	portrait_path = "gfx/leaders/South America/Portrait_South_America_Generic_navy_1.dds"
+	traits = { }
+	skill = 1
+}


### PR DESCRIPTION
Updating the history file for Honduras to ensure that it uses the new leader portrait. So that integrating my Honduras mod can be easier, I had this file match the one in my mod (this file and the cosmetic tags file are the only two base game files that my mod affects)