### PR TITLE
#111 Stops the French ban communism event if banned through decision

### DIFF
--- a/events/France.txt
+++ b/events/France.txt
@@ -2004,6 +2004,7 @@ country_event = {
 		tag = FRA
 		SOV = { has_government = communism }
 		has_government = democratic
+		communism > 0.05
 		communism < 0.5
 		has_global_flag = sov_yes_pact
 	}


### PR DESCRIPTION
The "Ban Communism" decision doesn't add a flag that this event can use in its trigger. Instead, it adds a variable to the communism ideology which prevents it from rising. Having a 5% communism requirement for this event should stop France from getting the "Ban Communism" event if it has already banned communism through a decision.