### PR TITLE
#100 Fixing Vichy France

### DIFF
--- a/events/France.txt
+++ b/events/France.txt
@@ -1456,6 +1456,37 @@ country_event = {
 						set_state_controller = 31
 					}
 			}
+			start_civil_war = {
+				ideology = fascism
+				size = 0.9
+				capital = 26
+				states = { 26 21 22 31 25 20 32 33 1 735 677 680 554 458 462 461 513 459 460 665 553 272 556 543 706 708 713 268 557 514 515 }
+				states_filter = {
+					owner = { original_tag = FRA }
+					OR = {		
+						# lets not involve syria or tunisia in civil war flip if occupied by other party
+						AND = {
+							OR = {
+								state = 554
+								state = 680
+								state = 677
+								state = 458
+							}
+							controller = { # FRA not controller
+								original_tag = FRA
+							}
+						}
+						NOT = {
+							OR = {
+								state = 554
+								state = 680
+								state = 677
+								state = 458
+							}						
+						}
+					}					
+				}
+			}
 		}
 		random_other_country = {
 			limit = { original_tag = FRA has_government = fascism }
@@ -1716,6 +1747,37 @@ country_event = {
 						set_state_controller = 31
 					}
 			}
+		start_civil_war = {
+				ideology = neutrality
+				size = 0.5
+				capital = 26
+				states = { 26 21 22 31 25 20 32 33 1 735 677 680 554 458 462 461 513 459 460 665 553 272 556 543 706 708 713 268 557 514 515 }
+				states_filter = {
+					owner = { original_tag = FRA }
+					OR = {		
+						# lets not involve syria or tunisia in civil war flip if occupied by other party
+						AND = {
+							OR = {
+								state = 554
+								state = 680
+								state = 677
+								state = 458
+							}
+							controller = { # FRA not controller
+								original_tag = FRA
+							}
+						}
+						NOT = {
+							OR = {
+								state = 554
+								state = 680
+								state = 677
+								state = 458
+							}						
+						}
+					}					
+				}
+			}	
 		}
 		random_other_country = {
 			limit = { original_tag = FRA has_government = neutrality }


### PR DESCRIPTION
Adds code from the basegame which creates Vichy France through a Civil War if France is defeated by Germany. This code was removed from the R56 France event file for some reason, and it was preventing Vichy France from being formed (with Free France maintaining ownership of southern France)