### PR TITLE
Issue #131 Fixes

### DIFF
--- a/common/national_focus/bulgaria.txt
+++ b/common/national_focus/bulgaria.txt
@@ -353,15 +353,21 @@ focus_tree = {
 		id = BUL_tripartite_pact
 		icon = GFX_goal_tripartite_pact
 		prerequisite = { focus = BUL_reclaim_old_territories }
-		mutually_exclusive = { focus = BUL_greater_bulgaria focus = BUL_join_comintern focus = BUL_balkan_communist_federation focus = BUL_balkan_entente }
+		mutually_exclusive = { focus = BUL_greater_bulgaria focus = BUL_join_comintern focus = BUL_balkan_communist_federation focus = BUL_balkan_entente focus = BUL_slavic_allegiance}
 		x = 5
 		y = 5
 		cost = 10
 		ai_will_do = {
-			factor = 60
+			factor = 10
 			modifier = {
-				factor = 100
+				factor = 4
 				is_historical_focus_on = yes
+			}
+			modifier = {
+				factor = 0.1
+				NOT = {
+				ITA = {is_in_faction_with = GER}
+			}
 			}
 		}
 
@@ -505,6 +511,10 @@ focus_tree = {
 		cost = 10
 		ai_will_do = {
 			factor = 10
+			modifier = {
+				factor = 0.1
+				strength_ratio = { tag = GRE ratio < 1.2 }
+			}
 		}
 
 		available_if_capitulated = no
@@ -535,6 +545,10 @@ focus_tree = {
 		cost = 10
 		ai_will_do = {
 			factor = 10
+			modifier = {
+				factor = 0.1
+				strength_ratio = { tag = ROM ratio < 1.2 }
+			}
 		}
 
 		available_if_capitulated = no
@@ -670,6 +684,10 @@ focus_tree = {
 		cost = 10
 		ai_will_do = {
 			factor = 10
+			modifier = {
+				factor = 0.1
+				strength_ratio = { tag = ROM ratio < 1.2 }
+			}
 		}
 
 		available_if_capitulated = no
@@ -862,7 +880,7 @@ focus_tree = {
 		id = BUL_slavic_allegiance
 		icon = GFX_goal_support_communism
 		prerequisite = { focus = BUL_exercise_direct_power }
-		mutually_exclusive = { focus = BUL_nationalist_union_of_bulgaria }
+		mutually_exclusive = { focus = BUL_nationalist_union_of_bulgaria  focus = BUL_tripartite_pact}
 		x = 11
 		y = 3
 		cost = 10

--- a/events/Bulgarians.txt
+++ b/events/Bulgarians.txt
@@ -470,7 +470,7 @@ country_event = {
 		create_wargoal = {
 			type = take_state_focus
 			target = GRE
-			generator = { 341 }
+			generator = { 184 }
 		}
 	}
 }


### PR DESCRIPTION
Made the Tripartite Pact focus and Slavic Allegiance focuses mutually exclusive (no more ticking communism when Bulgaria joins the Axis) and added a modifier that makes Bulgaria less likely to take this focus before Italy joins the Axis (I also changed the base from 100 to 10, and the historical focuses modifier from 60 to 4). I also added strength checks to the Romanian membership, demand Dobrudja, and demand Thrace focuses, which makes Bulgaria less likely to take these focuses when it is not strong than the country it's targeting.

User was corrected about the wargoal, Bulgaria was getting a wargoal against Greece for a province they didn't have (now fixed in the events file).

I tested the Demand Thrace and Dobrudja events, I can't reproduce the user's issue (might have been caused by the tag switching, but I'm not sure)