### PR TITLE
Issue #143 Found the placeholders

### DIFF
--- a/interface/unitview.gfx
+++ b/interface/unitview.gfx
@@ -719,6 +719,18 @@ spriteTypes = {
 		name = "GFX_attached_air_bg"
 		textureFile = "gfx/interface/attached_air_bg.dds"
 	}
+	spriteType = {
+		name = "GFX_3d_view_placeholder"
+		textureFile = "gfx/interface/3d_view_placeholder.dds"
+	}
+	spriteType = {
+		name = "GFX_3d_view_placeholder_2"
+		textureFile = "gfx/interface/3d_view_placeholder.dds"
+	}
+	spriteType = {
+		name = "GFX_3d_view_placeholder_3"
+		textureFile = "gfx/interface/3d_view_placeholder.dds"
+	}
 }
 	
 	


### PR DESCRIPTION
It looks like Paradox added new Sprite types for placeholders in one of the files that R56 overrides. Adding the code from the base game removes that placeholder message from the error log.