### PR TITLE
Balance Adjustment to France and Iran. Select countries get Amour car as starting tech

### DIFF
--- a/common/national_focus/france.txt
+++ b/common/national_focus/france.txt
@@ -1557,7 +1557,7 @@ focus_tree = {
 		icon = GFX_goal_generic_neutrality_focus
 		x = 19
 		y = 0
-		cost = 10
+		cost = 8
 
 		available_if_capitulated = yes
 
@@ -1565,7 +1565,7 @@ focus_tree = {
 			factor = 100
 		}
 		completion_reward = {
-			add_political_power = 120	
+			add_political_power = 100	
 			news_event = { id = france.100 hours = 24 }
 		}
 	}
@@ -1577,7 +1577,7 @@ focus_tree = {
 		mutually_exclusive = { focus =  FRA_matignon_agreements_amendement  }
 		x = 18
 		y = 1
-		cost = 10
+		cost = 8
 
 		available_if_capitulated = yes
 
@@ -1585,7 +1585,7 @@ focus_tree = {
 			factor = 100
 		}
 		completion_reward = {
-			add_stability = 0.05
+			add_stability = 0.04
 			add_timed_idea = { idea = FRA_matignon_agreements1 days = 290 }
 		}
 	}
@@ -1597,7 +1597,7 @@ focus_tree = {
 		mutually_exclusive = { focus =  FRA_social_reforms }
 		x = 20
 		y = 1
-		cost = 10
+		cost = 8
 
 		available_if_capitulated = yes
 
@@ -1621,7 +1621,7 @@ focus_tree = {
 		mutually_exclusive = { focus = FRA_radicalize_front }
 		x = 18
 		y = 2
-		cost = 10
+		cost = 9
 		
 		available = {
 			NOT = { has_global_flag = front_explosed }
@@ -1650,7 +1650,7 @@ focus_tree = {
 		mutually_exclusive = { focus = FRA_radicalize_front }
 		x = 20
 		y = 2
-		cost = 10
+		cost = 9
 
 		available_if_capitulated = yes
 
@@ -1673,7 +1673,7 @@ focus_tree = {
 		}
 		x = 19
 		y = 3
-		cost = 10
+		cost = 8
 
 		available_if_capitulated = yes
 
@@ -1699,7 +1699,7 @@ focus_tree = {
 		mutually_exclusive = { focus = FRA_intervention }
 		x = 20
 		y = 4
-		cost = 10
+		cost = 9
 
 		available_if_capitulated = yes
 
@@ -1725,7 +1725,7 @@ focus_tree = {
 		}
 		x = 18
 		y = 4
-		cost = 10
+		cost = 9
 
 		available_if_capitulated = yes
 
@@ -1759,7 +1759,7 @@ focus_tree = {
 	 	}
 		x = 18
 		y = 5
-		cost = 10
+		cost = 9
 
 		ai_will_do = {
 			factor = 0.5
@@ -1809,7 +1809,7 @@ focus_tree = {
 	 	mutually_exclusive = { focus = FRA_little_entente }
 		x = 20
 		y = 5
-		cost = 10
+		cost = 9
 
 		available_if_capitulated = yes
 

--- a/common/national_focus/italy.txt
+++ b/common/national_focus/italy.txt
@@ -1408,7 +1408,7 @@ focus_tree = {
 		y = 0
 		cost = 1
 		ai_will_do = {
-			factor = 1
+			factor = 10
 		}	
 		completion_reward = {
 			add_stability = -0.25

--- a/common/national_focus/persia.txt
+++ b/common/national_focus/persia.txt
@@ -1355,6 +1355,7 @@ focus_tree = {
 		y = 0
 		cost = 10
 		available = {
+		date > 1936.1.31
 		}
 		ai_will_do = {
 			factor = 0.1
@@ -1365,7 +1366,7 @@ focus_tree = {
 		}
 
 		completion_reward = {
-			add_political_power = 120
+			add_political_power = 25
 		}
 	}
 	
@@ -1385,6 +1386,7 @@ focus_tree = {
 			IRQ = {
 				r56_script_target_is_sane = yes
 			}
+				date > 1937.4.31
 		}
 			
 		bypass = {
@@ -1425,6 +1427,7 @@ focus_tree = {
 				r56_script_target_is_sane = yes
 			}
 			controls_state = 291
+			date > 1938.4.1
 		}
 			
 		bypass = {
@@ -1562,6 +1565,7 @@ focus_tree = {
 			AFG = {
 				r56_script_target_is_sane = yes
 			}
+			date > 1938.1.1
 		}
 			
 		bypass = {
@@ -1632,10 +1636,11 @@ focus_tree = {
 			PER = {
 				controls_state = 291
 			}
+			date > 1937.2.1
 		}
 		x = 12
 		y = 1
-		cost = 5
+		cost = 10
 		ai_will_do = {
 			factor = 10	
 		}

--- a/history/countries/ARG - Argentina.txt
+++ b/history/countries/ARG - Argentina.txt
@@ -8,6 +8,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	tech_mountaineers = 1

--- a/history/countries/AST - Australia.txt
+++ b/history/countries/AST - Australia.txt
@@ -8,6 +8,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/AUS - Austria.txt
+++ b/history/countries/AUS - Austria.txt
@@ -13,6 +13,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	tech_recon = 1

--- a/history/countries/BEL - Belgium.txt
+++ b/history/countries/BEL - Belgium.txt
@@ -23,6 +23,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/BRA - Brazil.txt
+++ b/history/countries/BRA - Brazil.txt
@@ -9,6 +9,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/BUL - Bulgaria.txt
+++ b/history/countries/BUL - Bulgaria.txt
@@ -11,6 +11,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/CAN - Canada.txt
+++ b/history/countries/CAN - Canada.txt
@@ -13,6 +13,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/CHI - China.txt
+++ b/history/countries/CHI - China.txt
@@ -23,6 +23,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/CZE - Czechoslovakia.txt
+++ b/history/countries/CZE - Czechoslovakia.txt
@@ -7,6 +7,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/DDR - East Germany.txt
+++ b/history/countries/DDR - East Germany.txt
@@ -6,6 +6,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/DEN - Denmark.txt
+++ b/history/countries/DEN - Denmark.txt
@@ -11,7 +11,9 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
+
 	infantry_weapons = 1
 	infantry_weapons1 = 1
 	tech_support = 1		

--- a/history/countries/ENG - Britain.txt
+++ b/history/countries/ENG - Britain.txt
@@ -13,6 +13,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/EST - Estonia.txt
+++ b/history/countries/EST - Estonia.txt
@@ -15,7 +15,8 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
-	
+	gw_armored_car = 1
+
 	mil = 1
 	infantry_weapons = 1
 	infantry_weapons1 = 1
@@ -26,6 +27,7 @@ set_technology = {
 	early_destroyer = 1
 	early_submarine = 1
 	basic_submarine = 1
+	
 }
 
 set_convoys = 15

--- a/history/countries/FIN - Finland.txt
+++ b/history/countries/FIN - Finland.txt
@@ -13,6 +13,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1
@@ -23,6 +24,7 @@ set_technology = {
 	early_submarine = 1
 	early_heavy_cruiser = 1
 	early_fighter = 1
+
 }
 
 set_convoys = 5

--- a/history/countries/FRA - France.txt
+++ b/history/countries/FRA - France.txt
@@ -12,6 +12,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/GER - Germany.txt
+++ b/history/countries/GER - Germany.txt
@@ -9,6 +9,7 @@ set_technology = {
 	etax_doctrine = 1
 	camo = 1
 	sniper_rifle = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/GRE - Greece.txt
+++ b/history/countries/GRE - Greece.txt
@@ -14,6 +14,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/HUN - Hungary.txt
+++ b/history/countries/HUN - Hungary.txt
@@ -12,6 +12,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/ITA - Italy.txt
+++ b/history/countries/ITA - Italy.txt
@@ -21,6 +21,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/JAP - Japan.txt
+++ b/history/countries/JAP - Japan.txt
@@ -20,6 +20,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/MEX - Mexico.txt
+++ b/history/countries/MEX - Mexico.txt
@@ -8,6 +8,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	# infantry
 	infantry_weapons = 1
@@ -27,7 +28,6 @@ set_technology = {
 	
 	# vehicles 
 	gwtank = 1
-	
 	# ships 
 	early_battleship = 1
 	early_light_cruiser = 1

--- a/history/countries/NOR - Norway.txt
+++ b/history/countries/NOR - Norway.txt
@@ -15,6 +15,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/NZL - New Zealand.txt
+++ b/history/countries/NZL - New Zealand.txt
@@ -11,6 +11,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/PER - Persia.txt
+++ b/history/countries/PER - Persia.txt
@@ -14,6 +14,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/PHI - Philippines.txt
+++ b/history/countries/PHI - Philippines.txt
@@ -9,6 +9,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/POL - Poland.txt
+++ b/history/countries/POL - Poland.txt
@@ -10,6 +10,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/POR - Portugal.txt
+++ b/history/countries/POR - Portugal.txt
@@ -13,6 +13,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	gnr = 1
 	fec = 1

--- a/history/countries/ROM - Romania.txt
+++ b/history/countries/ROM - Romania.txt
@@ -12,6 +12,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	tech_support = 1		
 	tech_engineers = 1

--- a/history/countries/SAF - South Africa.txt
+++ b/history/countries/SAF - South Africa.txt
@@ -11,6 +11,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/SOV - Soviet union.txt
+++ b/history/countries/SOV - Soviet union.txt
@@ -13,6 +13,7 @@ set_technology = {
 	etax_doctrine = 1
 	camo = 1
 	sniper_rifle = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/SWE - Sweden.txt
+++ b/history/countries/SWE - Sweden.txt
@@ -17,6 +17,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/SWI - Switzerland.txt
+++ b/history/countries/SWI - Switzerland.txt
@@ -9,6 +9,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/TUR - Turkey.txt
+++ b/history/countries/TUR - Turkey.txt
@@ -14,6 +14,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/USA - USA.txt
+++ b/history/countries/USA - USA.txt
@@ -12,6 +12,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/WGR - West Germany.txt
+++ b/history/countries/WGR - West Germany.txt
@@ -6,6 +6,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	infantry_weapons = 1
 	infantry_weapons1 = 1

--- a/history/countries/YUG - Yugoslavia.txt
+++ b/history/countries/YUG - Yugoslavia.txt
@@ -24,6 +24,7 @@ set_technology = {
 	# Extended Techologies
 	etax_doctrine = 1
 	camo = 1
+	gw_armored_car = 1
 	
 	tech_support = 1		
 	tech_engineers = 1


### PR DESCRIPTION
My last pull request before the next patch. I'm afraid I wasn't able to get the Ethiopia rework done for this cycle as planned. But it'll be worth the wait!!!

**Balance**
I always stride on the side of caution of making balance changes to countries. But after talking to the community, these where some common sense changes that should be made 

**France**
> France has to go though five focus to join the allies, while only having to go though four to join the axis or Comitern. It just made sense to lower some of the focus times. 

-The first five focuses of the join the allies/little entente path have had their compilation time lowed slightly.  Small nerfs to Legislative session award (120 PP --> 100 PP) and Status quo stability reward (5%-->4%) where made to compensate for this buff. 

**Iran**

> Iran should be a wildcard in the middle east. But with a talent player at the helm it can eat it's neighbors and become powerful stupidly fast. While as a minor it should have the power to expand and have some OP focuses. This was a bit much.... 

-Check the time. Iran's revive the empire tree has time checks on focuses now. 

**YOU GET A CAR, YOU GET A CAR**

> Gave some countries great war amour car as starting tech 




 