### PR TITLE
Fixed Ethiopian Infantry Expert having "Not: Purged By Stalin" requir…

### DIFF
--- a/common/ideas/ethiopia.txt
+++ b/common/ideas/ethiopia.txt
@@ -394,8 +394,7 @@ ideas = {
 				original_tag = ETH	
 			}
 			available =  
-			{
-				NOT = { has_country_flag = purge_1_group_b }	
+			{	
 				has_completed_focus = ETH_ferenghi
 			}
 


### PR DESCRIPTION
…ement.

The Ethiopian infantry expert "Wehib Pasha" unlocked through the The Ferenghi focus also had a "Not: Purged by Stalin" requirement which obviously makes no sense - so I got rid of it. Simple. (I even researched and he was not related to the Soviet Union in any way)