### PR TITLE
Issue #160 No repeating event

### DIFF
--- a/events/ENF_england_events.txt
+++ b/events/ENF_england_events.txt
@@ -547,7 +547,9 @@ country_event = {
 	title = englandmod.23.t
 	desc = englandmod.23.d
 	trigger = {
-		NOT = { is_subject_of = ENG }
+		NOT = { is_subject_of = ENG 
+		has_country_flag = kept_dominion_fascist_influence
+		}
 		has_idea = dominion_fascist_influence
 	}
 	fire_only_once = yes
@@ -559,6 +561,7 @@ country_event = {
 	option = {
 		name = englandmod.23.b
 		ai_chance = { factor = 10 }
+		set_country_flag = kept_dominion_fascist_influence	
 		}
 	mean_time_to_happen = {
 		days = 1


### PR DESCRIPTION
Choosing to keep fascism will give you a flag, which should stop this event from firing multiple times