### PR TITLE
Intergrating GFX along with ""fixes"".

### DIFF
--- a/common/national_focus/argentina.txt
+++ b/common/national_focus/argentina.txt
@@ -83,7 +83,7 @@ focus_tree = {
 	
 	focus = {
 		id = ARG_study_foreign_tanks
-		icon = GFX_goal_generic_position_armies
+		icon = GFX_goal_tank_map
 		prerequisite = { focus = ARG_motorized_army }
 		x = 1
 		y = 3
@@ -151,7 +151,7 @@ focus_tree = {
 	
 	focus = {
 		id = ARG_cruiser_tanks_experiments
-		icon = GFX_goal_generic_army_tanks
+		icon = GFX_goal_tank_offensive
 		prerequisite = { focus = ARG_tanks_modernization }
 		mutually_exclusive = { focus = ARG_heavy_tanks_experiments }
 		x = 0
@@ -1683,7 +1683,7 @@ focus_tree = {
 		
 		focus = {
 				id = ARG_industrial_development
-				icon = GFX_focus_generic_industry_1
+				icon = GFX_focus_focus_generic_industry_1
 				prerequisite = { focus = ARG_imports_substitution }
 				x = 31
 				y = 3

--- a/common/national_focus/belgium.txt
+++ b/common/national_focus/belgium.txt
@@ -2533,7 +2533,7 @@ focus_tree = {
 	}		
     focus = {
         id = tblra_transform_the_congo2
-        icon = GFX_focus_generic_industry_1
+        icon = GFX_focus_focus_generic_industry_1
         relative_position_id = tblra_urban_projects_capital
 		x = -4
         y = 2

--- a/common/national_focus/china_nationalist.txt
+++ b/common/national_focus/china_nationalist.txt
@@ -978,7 +978,7 @@ focus_tree = {
 	
 	focus = {
 		id = KMT_industrial_effort 
-		icon = GFX_focus_generic_industry_1
+		icon = GFX_focus_focus_generic_industry_1
 		x = 11
 		y = 0
 		cost = 10

--- a/common/national_focus/congo.txt
+++ b/common/national_focus/congo.txt
@@ -2392,7 +2392,7 @@ focus_tree = {
 	}	
     focus = {
         id = COG_transform_the_congo2
-        icon = GFX_focus_generic_industry_1
+        icon = GFX_focus_focus_generic_industry_1
 		relative_position_id = COG_industrial_effort
         x = -1
         y = 1

--- a/common/national_focus/sweden.txt
+++ b/common/national_focus/sweden.txt
@@ -1059,7 +1059,7 @@ focus_tree = {
 	
 	focus = {
 		id = SWE_claim_aland
-		icon = GFX_focus_renounce_the_treaty_of_triannon
+		icon = GFX_focus_renounce_the_treaty_of_trianon
 		prerequisite = { focus = SWE_abandon_neutrality }
 		
 		bypass = {


### PR DESCRIPTION
Integrated some of the recent GFX into Argentina's focuses along with fixing Sweden's Åland Convention focus icon not displaying properly.

Lastly, replacing all generic industries with focus_focus generic industry because PDX did something by mistake - so they won't show up basically.