### PR TITLE
Issue #4 Fixing the Hawker Hurricane Graphic

### DIFF
--- a/interface/replace/r56e_technologies.gfx
+++ b/interface/replace/r56e_technologies.gfx
@@ -2859,7 +2859,7 @@ spriteTypes = {
 	
 	SpriteType = {
 		name = "GFX_ENG_fighter_equipment_1_medium"
-		texturefile = "gfx/interface/technologies/ENG_fighter_equipment_1.dds"
+		texturefile = "gfx/interface/technologies/ENG_fighter1.dds"
 	}
 	
 	SpriteType = {


### PR DESCRIPTION
I managed to reproduce this error and found a disconnect between the sprites file and the graphic name. Changing GFX_ENG_fighter_equipment_1_medium ' s target to the vanilla Hurricane file fixes the issue and the Hurricane can now be seen in the production screen.