### PR TITLE
Issue #7 Chinese United Front Check

### DIFF
--- a/events/China.txt
+++ b/events/China.txt
@@ -641,7 +641,15 @@ country_event = {
 	option = {
 		ai_chance = { factor = 100 }
 		name = china.100.a
-		create_faction = chinese_united_front
+		if = {
+			limit = {
+				CHI = { is_in_faction = no }
+			}
+			CHI = {
+				set_rule = { can_create_factions = yes }
+				create_faction = chinese_united_front
+			}
+		}
 		add_ideas = KMT_united_front
 		#load_oob = "CHI_united_front"
 		set_global_flag = CHI_unite


### PR DESCRIPTION
Adds an if statement to the Chinese United Front event which will stop China from forming a new United Front faction if it is already in a faction. This seems to be the only event that does not check if China is already in a faction before forming the United Front (all of the new WTT United Front events have this check), and adding this if statement should resolve the gamebreaking issue. As for the warlords, I think having different events for inviting them (one for when the United Front already exists, one to found the United Front) could be part of a larger China rework.