### PR TITLE
Issue #226 Fixing the Construction Company Icon

### DIFF
--- a/interface/replace/r56_ideas.gfx
+++ b/interface/replace/r56_ideas.gfx
@@ -2319,7 +2319,7 @@ spriteTypes = {
 	
 		spriteType = {
 		name = "GFX_idea_HON_rmc"
-		texturefile = "gfx/interface/ideas/hon_rmc.dds"
+		texturefile = "gfx/interface/ideas/HON_rmc.dds"
 	}
 	
 		spriteType = {


### PR DESCRIPTION
Apparently graphics files names are case sensitive in the workshop version of R56 but not the beta. TIL