### PR TITLE
Fixing a CTD caused by forming Vichy France

### DIFF
--- a/events/France.txt
+++ b/events/France.txt
@@ -1471,15 +1471,54 @@ country_event = {
 				}				
 			}		
 			##add checks if general exists
-			remove_unit_leader = 801
-			remove_unit_leader = 802
-			remove_unit_leader = 803
-			remove_unit_leader = 804
-			remove_unit_leader = 805
-			remove_unit_leader = 806
-			remove_unit_leader = 807
-			#remove_unit_leader = 808 #René-Émile Godfroy
-			remove_unit_leader = 809
+			if = {
+			limit = {
+					has_unit_leader = 801
+			}
+				remove_unit_leader = 801
+			}
+			if = {
+			limit = {
+					has_unit_leader = 802
+			}
+				remove_unit_leader = 802
+			}
+			if = {
+			limit = {
+					has_unit_leader = 803
+			}
+				remove_unit_leader = 803
+			}
+			if = {
+			limit = {
+					has_unit_leader = 804
+			}
+				remove_unit_leader = 804
+			}
+			if = {
+			limit = {
+					has_unit_leader = 805
+			}
+				remove_unit_leader = 805
+			}
+			if = {
+			limit = {
+					has_unit_leader = 806
+			}
+				remove_unit_leader = 806
+			}
+			if = {
+			limit = {
+					has_unit_leader = 807
+			}
+				remove_unit_leader = 807
+			}
+			if = {
+			limit = {
+					has_unit_leader = 809
+			}
+				remove_unit_leader = 809
+			}
 			add_ideas = FRA_FREE_army
 			remove_ideas = FRA_inflation1
 			remove_ideas = FRA_inflation2


### PR DESCRIPTION
Someone who plays R56 was nice enough to upload his save game, and I found the source of his crash. The event where France surrenders and becomes Vichy was trying to remove a leader that France didn't have. Adding checks to all the leader removals seems to fix this CTD (although the game lags for a few seconds when Vichy is formed)