### PR TITLE
Removed the Empty Space on Brussel-Bruxelles

### DIFF
--- a/localisation/replace/r56_victory_points_l_english.yml
+++ b/localisation/replace/r56_victory_points_l_english.yml
@@ -1,6 +1,7 @@
 ﻿l_english:
 
- VICTORY_POINTS_516:0 " Brussel-Bruxelles"
+ VICTORY_POINTS_6583:0 "Luxembourg City"
+ VICTORY_POINTS_516:0 "Brussel-Bruxelles"
  VICTORY_POINTS_1056:0 "Homs"
  VICTORY_POINTS_1088:0 "Latakia"
  VICTORY_POINTS_1554:0 "Samarkand"


### PR DESCRIPTION
and Luxembourg have a proper city name.