### PR TITLE
Updated bypass for Eastern Claims.

### DIFF
--- a/common/national_focus/germany.txt
+++ b/common/national_focus/germany.txt
@@ -3178,19 +3178,24 @@ focus_tree = {
 					has_completed_focus = GER_anschluss
 				}
 			bypass = {
-					188 = {
+				OR = {
+					NOT = { country_exists = LIT }
+					AND = {
+						188 = {
 							is_owned_by = GER
 						}
-					85 = {
+						85 = {
 							is_owned_by = GER
 						}
-					86 = {
+						86 = {
 							is_owned_by = GER
 						}
-					788 = {
+						788 = {
 							is_owned_by = GER
 						}
+					}
 				}
+			}
 			completion_reward = {
 					188 = {
 							add_claim_by = GER


### PR DESCRIPTION
The 'Assert Eastern Claims' focus now has a bypass if Lithuania doesn't exist in the first place.