### PR TITLE
Making stuff appear in the launcher.

### DIFF
--- a/1956_beta.mod
+++ b/1956_beta.mod
@@ -1,8 +1,0 @@
-﻿name="The Road to 56 [Beta]"
-path="mod/1956_beta/"
-tags={
-    "Beta"
-}
-picture="box.jpg"
-remote_file_id="1088963694"
-supported_version="1.7.*"

--- a/descriptor.mod
+++ b/descriptor.mod
@@ -1,0 +1,3 @@
+﻿picture="box.jpg"
+remote_file_id="1088963694"
+supported_version="1.8.*"


### PR DESCRIPTION
! Read !
This is to make the GitHub mod version appear in the new launcher. However, it still requires some tweaking locally.

Basically: Every mod now has to have a descriptor.mod file inside the mod's folder which contains everything EXCEPT for the name and path. While the .mod file outside the mod's folder needs to contain ONLY the name and path.

So the descriptor.mod looks like this inside: 
﻿picture="box.jpg"
remote_file_id="1088963694"
supported_version="1.8.*"

While the .mod file outside the mod folder looks like this on the inside:
name="The Road to 56 [Beta]"
path="mod/1956_beta/"

This pull request fixes the descriptor.mod for everyone but it's the .mod file outside the mod's folder which needs to be tweaked by everyone seperate.
I also removed the tags because they don't seem to do anything in the new launcher anymore.