### PR TITLE
Typofix in KOR_l_english.yml

### DIFF
--- a/localisation/KOR_l_english.yml
+++ b/localisation/KOR_l_english.yml
@@ -10,7 +10,7 @@
 r56_KOR_decision_kim_il_sung_takes_command:0 "Kim Il Sung Takes Command of the Army"
 #Advisors
 #Companies
-KOR_generic_light_aircraft_manufacturer:0 "Pyeongtayk Airbase Workshop"
+KOR_generic_light_aircraft_manufacturer:0 "Pyeongtaek Airbase Workshop"
 KOR_generic_infantry_equipment_manufacturer:0 "Jinsen Arsenal"
 KOR_generic_industrial_concern:0 "Hyundai Engineering & Construction"
 KOR_generic_electronics_concern:0 "Samsung" 


### PR DESCRIPTION
Fixed small typo; Pyeongtayk to Pyeongtaek.

Reference: https://en.wikipedia.org/wiki/Pyeongtaek