### PR TITLE
Neutral Boosting

### DIFF
--- a/common/ideologies/00_ideologies.txt
+++ b/common/ideologies/00_ideologies.txt
@@ -240,7 +240,7 @@ ideologies = {
 		}
 		faction_modifiers = {
 		}
-		can_be_boosted = no
+
 		can_collaborate = yes
 
 		ai_neutral = yes #Uses the Non-Aligned AI behaviour.


### PR DESCRIPTION
Allow boosting for neutral ideologies (similar to the vanilla 1.9.1 update). Especially with addition of all the alternative monarchistic options for majors, neutral is not longer just "neutral" but a faction for its own.