### PR TITLE
Minor optimizations and bugfixes Chile

### DIFF
--- a/common/ideas/chile.txt
+++ b/common/ideas/chile.txt
@@ -7,10 +7,8 @@ ideas = {
 			}
 
 			allowed_civil_war = {
-				OR = { 
-					has_government = neutrality
-					has_government = communism
-					has_government = democratic
+				NOT = { 
+					has_government = fascism
 				}
 			}
 
@@ -31,10 +29,8 @@ ideas = {
 			}
 
 			allowed_civil_war = {
-				OR = { 
-					has_government = neutrality
-					has_government = communism
-					has_government = democratic
+				NOT = { 
+					has_government = fascism
 				}
 			}
 
@@ -336,7 +332,7 @@ ideas = {
 			
 			picture = FRA_scw_intervention_republicans_focus
 		}
-		
+
 		CHL_command_economy = {
 			
 			allowed = {
@@ -442,8 +438,10 @@ ideas = {
 			}
 
 			allowed_civil_war = {
-				has_government = fascism
-				has_government = neutrality
+				OR = {
+					has_government = fascism
+					has_government = neutrality
+				}
 			}
 
 			available = {
@@ -674,12 +672,13 @@ ideas = {
 					has_government = neutrality
 				}
 			}
-
 	
 			available = {
-				OR = {
-					is_subject = no
-					is_puppet = no
+				NOT = {
+					OR = {
+						is_subject = yes
+						is_puppet = yes
+					}
 				}
 			}
 
@@ -719,7 +718,7 @@ ideas = {
 			picture = generic_manpower_bonus
 		}
 		
-		CHL_spread_revolution_idea  = {
+		CHL_spread_revolution_idea = {
 			
 			allowed = {
 				always = no
@@ -775,10 +774,7 @@ ideas = {
 				OR = {
 					is_subject = yes
 					is_puppet = yes
-				}
-				OR = {
 					has_government = fascism
-					has_government = neutrality
 				}
 			}
 
@@ -933,7 +929,7 @@ ideas = {
 			
 			picture = FRA_scw_intervention_republicans_focus
 		}
-		
+
 		CHL_anti_american_idea = {
 			
 			allowed = {
@@ -966,10 +962,9 @@ ideas = {
 
 			targeted_modifier = { tag = USA attack_bonus_against = 0.10 defense_bonus_against = 0.10 }
 
-			
 			picture = saf_ossewabrandwag_2
 		}
-		
+
 		CHL_anti_capitalist_idea = {
 		
 			allowed = {
@@ -992,17 +987,15 @@ ideas = {
 				}
 			}
 			
-			
 			modifier = {
 				industrial_capacity_factory = -0.20
 				production_speed_buildings_factor = 0.20
-				local_building_slots_factor = 0.20
+				global_building_slots_factor = 0.20
 			}
 			
 			picture = generic_central_management
 		}
-		
-		
+
 		CHL_agrarian_reform = {
 		
 			allowed = {
@@ -1024,13 +1017,13 @@ ideas = {
 		}
 		
 	}
-	
+
 	political_advisor = {
 
 		CHL_generic_propaganda = {
 
 			picture = generic_political_advisor_europe_2
-				
+			
 			allowed = {
 				original_tag = CHL
 			}
@@ -1069,7 +1062,7 @@ ideas = {
 
 			allowed = {
 				original_tag = CHL
-			}		
+			}
 
 			traits = { communist_revolutionary }
 			picture = generic_political_advisor_south_america_2
@@ -1091,10 +1084,8 @@ ideas = {
 				factor = 0.1
 				modifier = {
 					add = 100
-					AND = {
-						has_completed_focus = CHL_the_popular_front
-						is_historical_focus_on = no
-					}
+					has_completed_focus = CHL_the_popular_front
+					is_historical_focus_on = no
 				}
 			}
 		}
@@ -1103,7 +1094,7 @@ ideas = {
 
 			allowed = {
 				original_tag = CHL
-			}		
+			}
 
 			traits = { democratic_reformer }
 			picture = generic_political_advisor_south_america_3
@@ -1111,7 +1102,7 @@ ideas = {
 			available = {
 				has_completed_focus = CHL_the_popular_front
 				NOT = {
-					has_idea = 	CHL_volodia_teitelboim
+					has_idea = CHL_volodia_teitelboim
 				}
 			}
 
@@ -1145,7 +1136,7 @@ ideas = {
 		CHL_miguel_cruchaga_tacomal = {
 
 			picture = generic_political_advisor_south_america_2
-				
+			
 			allowed = {
 				original_tag = CHL
 			}
@@ -1173,7 +1164,7 @@ ideas = {
 			
 			allowed = {
 				original_tag = CHL
-			}		
+			}
 			
 			traits = { army_chief_maneuver_2 }
 			
@@ -1242,8 +1233,7 @@ ideas = {
 			ai_will_do = {
 				factor = 1
 			}
-		}		
-
+		}
 	}
 
 	navy_chief = {
@@ -1255,7 +1245,7 @@ ideas = {
 			allowed = {
 				original_tag = CHL
 			}
-					
+
 			traits = { navy_chief_maneuver_2 }
 			
 			ai_will_do = {
@@ -1270,7 +1260,7 @@ ideas = {
 			allowed = {
 				original_tag = CHL
 			}
-					
+			
 			traits = { navy_chief_decisive_battle_2 }
 			
 			ai_will_do = {
@@ -1296,7 +1286,7 @@ ideas = {
 				factor = 1
 			}
 		}
-		
+
 		CHL_arturo_espinoza_mujica = {
 			ledger = army
 
@@ -1344,7 +1334,7 @@ ideas = {
 				factor = 1
 			}
 		}
-		
+
 		CHL_gustavo_silva = {
 			ledger = navy
 
@@ -1360,7 +1350,7 @@ ideas = {
 				factor = 1
 			}
 		}
-	}	
+	}
 
 	theorist = {
 		CHL_carlos_fuentes_rabe = {
@@ -1393,7 +1383,7 @@ ideas = {
 			}
 			
 			traits = { naval_theorist }
-		}	
+		}
 
 		CHL_ariosto_herrera = {
 			ledger = air


### PR DESCRIPTION
Hi. Just a quick contribution for some oversights I noticed while playing. Tested on my end.

Streamlined allowed_civil_war section on r56_CHL_a_truly_radical_party, r56_CHL_the_popular_front.
CHL_anti_capitalist_idea used local_building_slots_factor rather than global_building_slots_factor, resulting in no effect.
CHL_communist_ban had missing OR on the allowed_civil_war section, making it impossible to fulfill. (You can't be 2 ideologies simultaneously)
Removed redundant AND in CHL_volodia_teitelboim (Its implicit)

The available section of CHL_spread_of_fascist reads: "If Chile it is not a puppet OR it is not a subject" AFAIK, you can't be both simultaneously, so it's always true. Changed so that if either is true, then the idea dies.
The cancel section of CHL_popular_front_frail was always true. Changed so the idea dies if Chile is not independent or fascist. It's gained while neutral, so that part was removed.
CHL_anti_american_idea is only canceled if Chile is not independent and democratic. I won't change it as it may be intentional (cancel only if USA puppets Chile).