### PR TITLE
Bugfixes and small optimisations ETH focus tree

### DIFF
--- a/common/national_focus/ethiopia.txt
+++ b/common/national_focus/ethiopia.txt
@@ -1,6 +1,6 @@
 #####################################################################
 #																	#
-#					       The Lion of Judah 				  		#
+#							The Lion of Judah 							#
 #																	#
 # 							FOCUS TREES	 							#
 #																 	#
@@ -14,11 +14,10 @@ focus_tree = {
 			add = 10
 			tag = ETH
 		}
-	
 	}
 
-    continuous_focus_position = { x = 1300 y = 800 }		
-	
+	continuous_focus_position = { x = 1300 y = 800 }
+
 default = no
 
 ###### DEVELOPMENT FOCUS ########
@@ -32,7 +31,7 @@ focus = {
 		cost = 10
 		ai_will_do = {
 			factor = 1
-		}	
+		}
 		completion_reward = {
 			add_resource = {
 				type = steel
@@ -42,19 +41,18 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
-	
+
 	focus = {
 		id = ETH_urban_factories
 		icon = GFX_focus_generic_industry_2
 		#text = "Urban Factories"
-		#available = {	}
 		prerequisite = { focus = ETH_land_development }
 		relative_position_id = ETH_land_development
 		x = 0
 		y = 1
 		cost = 10
 		ai_will_do = {
-		factor = 0.6 
+			factor = 0.6
 		}
 		completion_reward = {
 			271 = {
@@ -63,40 +61,38 @@ focus = {
 					type = industrial_complex
 					level = 2
 					instant_build = yes
-					}
 				}
 			}
-			search_filters = { FOCUS_FILTER_INDUSTRY }
 		}
-		
-		focus = {
+		search_filters = { FOCUS_FILTER_INDUSTRY }
+	}
+
+	focus = {
 		id = ETH_modern_technology
 		icon = GFX_goal_generic_production2
 		#text = "Foreign Contracts"
 		prerequisite = { 
-		focus = ETH_urban_factories
-		
+			focus = ETH_urban_factories
 		}
 		relative_position_id = ETH_urban_factories
 		x = 0
 		y = 1
 		cost = 10
-			ai_will_do = {
+		ai_will_do = {
 			factor = 0.6
 		}
 		completion_reward = {
-				#add_ideas = western_investment
-				add_tech_bonus = {
+			#add_ideas = western_investment
+			add_tech_bonus = {
 				name = industrial_bonus
 				bonus = 0.50
 				uses = 1
 				category = industry
 			}
-				
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
-		}
-	
+	}
+
 	focus = {
 		id = ETH_addiba_university
 		icon = GFX_goal_research_silver
@@ -108,14 +104,14 @@ focus = {
 		y = 2
 		cost = 10
 		ai_will_do = {
-		factor = 10
+			factor = 10
 		}
 		completion_reward = {
 			add_research_slot = 1
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
-	
+
 	focus = {
 		id = ETH_extra_research_slot_2
 		icon = GFX_focus_research
@@ -130,12 +126,10 @@ focus = {
 		cost = 10
 		completion_reward = {
 			add_research_slot = 1
-			}
-			search_filters = { FOCUS_FILTER_RESEARCH }
+		}
+		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
-		
-	
-	
+
 	focus = {
 		id = ETH_black_lions
 		icon = GFX_ITA_learn_from_the_ethiopian_war
@@ -145,11 +139,10 @@ focus = {
 		cost = 1
 		ai_will_do = { factor = 1 }
 		completion_reward = {
-				add_ideas = ETH_black_lion_corps
-		}		
-			
+			add_ideas = ETH_black_lion_corps
+		}
 	}
-		
+
 	focus = {
 		id = ETH_regimental_system
 		icon = GFX_goal_small_infantry
@@ -167,7 +160,7 @@ focus = {
 				any_claim = yes
 				has_war = yes
 			}
-		}	
+		}
 		completion_reward = {
 			add_tech_bonus = {
 				bonus = 1
@@ -200,13 +193,13 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
-	
+
 	focus = {
 		id = ETH_harar_academy
 		#text = "Harar Academy"
 		icon = GFX_focus_generic_military_academy
 		prerequisite = { 
-			focus = ETH_officer_schools 
+			focus = ETH_officer_schools
 		}
 		relative_position_id = ETH_officer_schools
 		x = 0
@@ -225,11 +218,9 @@ focus = {
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
 
-	
 	focus = {
 		id = ETH_mil_factory
 		icon = GFX_goal_generic_construct_mil_factory
-		
 		x = 0
 		y = 0
 		cost = 10
@@ -241,7 +232,7 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
-	
+
 	focus = {
 		id = ETH_mil_factory2
 		icon = GFX_goal_generic_construct_mil_factory
@@ -259,11 +250,11 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
-	
+
 	focus = {
 		id = ETH_silk_road_test
 		icon = GFX_goal_generic_construct_infrastructure
-		prerequisite = { focus = ETH_extra_research_slot_2  }
+		prerequisite = { focus = ETH_extra_research_slot_2 }
 		#text = "Land DEVELOPMENT"
 		x = 1
 		y = 6
@@ -297,11 +288,11 @@ focus = {
 					level = 2
 					instant_build = yes
 				}
-			}	
+			}
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
-	
+
 	focus = {
 		id = ETH_steel_industry
 		icon = GFX_focus_generic_steel
@@ -312,7 +303,7 @@ focus = {
 		cost = 10
 		ai_will_do = {
 			factor = 70
-		}	
+		}
 		completion_reward = {
 			add_resource = {
 				type = steel
@@ -322,7 +313,7 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
-	
+
 	focus = {
 		id = ETH_rare_metals
 		icon = GFX_goal_generic_construct_civ_factory
@@ -334,7 +325,7 @@ focus = {
 		cost = 10
 		ai_will_do = {
 			factor = 70
-		}	
+		}
 		completion_reward = {
 			add_resource = {
 				type = tungsten
@@ -354,7 +345,7 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
-	
+
 	focus = {
 		id = ETH_oil_industry
 		icon = GFX_goal_generic_oil_refinery
@@ -366,7 +357,7 @@ focus = {
 		cost = 10
 		ai_will_do = {
 			factor = 70
-		}	
+		}
 		completion_reward = {
 			add_resource = {
 				type = oil
@@ -378,16 +369,15 @@ focus = {
 				amount = 4
 				state = 271
 			}
-			
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
-	
+
 	##### END DEVELOPMENT FOCUS ######
-	
-	
+
+
 	######## WAR with ITALY TREE #####
-	
+
 	focus = {
 		id = ETH_christmas_offensive
 		icon = GFX_goal_generic_major_war
@@ -402,6 +392,9 @@ focus = {
 				has_war_with = ETH
 			}
 		}
+		bypass = {
+			NOT = { has_war_with = ITA }
+		}
 		ai_will_do = {
 			factor = 12
 		}
@@ -412,22 +405,23 @@ focus = {
 			}
 		}
 	}
-	
+
 	focus = {
 		id = ETH_national_mobilization
 		icon = GFX_goal_generic_army_mobilization
 		#text = "National Mobilization"
 		prerequisite = { focus = ETH_christmas_offensive }
-		available = {
-			has_idea = second_italo_ethiopian_war
-			country_exists = ITA
-			ITA = {
-				has_war_with = ETH
-			}
-		}
 		x = 10
 		y = 1
 		cost = 3
+		available = {
+			has_idea = second_italo_ethiopian_war
+			country_exists = ITA
+			ITA = { has_war_with = ETH }
+		}
+		bypass = {
+			NOT = { has_war_with = ITA }
+		}
 
 		ai_will_do = {
 			factor = 12
@@ -438,7 +432,7 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_MANPOWER }
 	}
-	
+
 	focus = {
 		id = ETH_homeland_defense
 		icon = GFX_goal_generic_defence
@@ -463,7 +457,7 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_STABILITY }
 	}
-	
+
 	focus = {
 		id = ETH_hold_line
 		icon = GFX_goal_generic_construction2
@@ -487,9 +481,9 @@ focus = {
 			add_ideas = ETH_hold_the_line
 		}
 	}
-	
+
 	##FORT TREE##
-	
+
 	focus = {
 		id = ETH_mountain_forts
 		#text = "Secure the Mountains"
@@ -553,7 +547,7 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_MANPOWER }
 	}
-	
+
 	focus = {
 		id = ETH_capital_forts
 		#text = "Secure the Capital"
@@ -581,36 +575,34 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_MANPOWER }
 	}
-	
+
 	focus = {
 		id = ETH_rain_iron 
 		icon = GFX_goal_fortify_city_AA
 		#text = "Urban Factories"
-		#available = {	}
+		#available = { }
 		prerequisite = { focus = ETH_capital_forts }
 		x = 14
 		y = 4
 		cost = 10
 		ai_will_do = {
-		factor = 0.1 
+			factor = 0.1 
 		}
 		completion_reward = {
 			#Fortify Capital w/	Bunker and province Anti-Air
 			271 = {
 				add_building_construction = {
 					type = anti_air_building
-					level = 3				
+					level = 3
 					instant_build = yes
 				}
 			}
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
-		}
-		
-	
-	
+	}
+
 	##### DIPLENGCY PATH ####
-	
+
 	focus = {
 		id = ETH_plea_to_lon
 		icon = GFX_goal_support_democracy
@@ -633,15 +625,14 @@ focus = {
 			NOT = {
 				has_war_with = ITA
 			}
-
 		}
 		completion_reward = {
 			add_political_power = 75
-			USA = {	add_opinion_modifier = { target = ITA modifier = unprovoked_aggression } }
-			ENG = {	add_opinion_modifier = { target = ITA modifier = unprovoked_aggression } }
-			FRA = {	add_opinion_modifier = { target = ITA modifier = unprovoked_aggression } }
-			SOV = {	add_opinion_modifier = { target = ITA modifier = unprovoked_aggression } }
-		}	
+			USA = { add_opinion_modifier = { target = ITA modifier = unprovoked_aggression } }
+			ENG = { add_opinion_modifier = { target = ITA modifier = unprovoked_aggression } }
+			FRA = { add_opinion_modifier = { target = ITA modifier = unprovoked_aggression } }
+			SOV = { add_opinion_modifier = { target = ITA modifier = unprovoked_aggression } }
+		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
 	}
 
@@ -660,9 +651,7 @@ focus = {
 
 		bypass = {
 			NOT = {
-				ITA = {
-					has_war_with = ETH
-				}
+				ITA = { has_war_with = ETH }
 			}
 		}
 
@@ -678,7 +667,7 @@ focus = {
 			custom_effect_tooltip = available_military_high_command
 		}
 	}
-	
+
 ##GERMAN EVENT BRANCH
 
 	focus = {
@@ -704,12 +693,11 @@ focus = {
 		}
 		completion_reward = {
 			country_event = { id = ethiopia.10011 days = 1 }
-			GER = {	add_opinion_modifier = { target = ITA modifier = large_decrease } }
-			ITA = {	add_opinion_modifier = { target = GER modifier = large_decrease } }
-			}
+			GER = { add_opinion_modifier = { target = ITA modifier = large_decrease } }
+			ITA = { add_opinion_modifier = { target = GER modifier = large_decrease } }
+		}
 	}
-	
-	
+
 	focus = {
 		id = ETH_german_design
 		icon = GFX_goal_generic_construct_mil_factory
@@ -718,8 +706,7 @@ focus = {
 		x = 7
 		y = 5
 		cost = 10
-		
-		
+
 		ai_will_do = {
 			factor = 50
 		}
@@ -727,7 +714,7 @@ focus = {
 			add_ideas = ETH_copy_german_design_focus
 		}
 	}
-	
+
 	focus = {
 		id = ETH_secure_seuz
 		icon = GFX_goal_generic_major_alliance
@@ -747,12 +734,12 @@ focus = {
 			add_state_core = 446
 			add_state_core = 447
 			add_state_core = 453
-			}
-			search_filters = { FOCUS_FILTER_ANNEXATION }
+		}
+		search_filters = { FOCUS_FILTER_ANNEXATION }
 	}
-	
+
 ##JAPANESE TREE BRANCH
-	
+
 	focus = {
 		id = ETH_japanese_assistance
 		icon = GFX_goal_generic_improve_relations
@@ -776,11 +763,11 @@ focus = {
 		}
 		completion_reward = {
 			country_event = { id = ethiopia.1002 days = 1 }
-			ETH = {	add_opinion_modifier = { target = JAP modifier = large_increase } }
-			JAP = {	add_opinion_modifier = { target = ETH modifier = large_increase } }
-			}
+			ETH = { add_opinion_modifier = { target = JAP modifier = large_increase } }
+			JAP = { add_opinion_modifier = { target = ETH modifier = large_increase } }
+		}
 	}
-	
+
 	focus = {
 		id = ETH_japanese_navy_focus
 		icon = GFX_goal_generic_major_alliance
@@ -800,10 +787,10 @@ focus = {
 			factor = 50
 		}
 		completion_reward = {
-		add_ideas = ETH_japanese_navy
+			add_ideas = ETH_japanese_navy
 		}
 	}
-	
+
 	focus = {
 		id = ETH_torpedoes_focus
 		icon = GFX_goal_generic_occupy_start_war
@@ -824,20 +811,19 @@ focus = {
 				uses = 1
 				category = dd_tech
 			}
-			
 			navy_experience = 25
 			add_ideas = ETH_the_long_lance
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
 
-## Mutual Second Wind TREE	
-	
+## Mutual Second Wind TREE
+
 	focus = {
 		id = ETH_lion_roar
 		icon = GFX_goal_generic_demand_territory
 		#text = "The Lion Roars"
-		prerequisite = { 
+		prerequisite = {
 			focus = ETH_japanese_navy_focus
 			focus = ETH_german_design
 		}
@@ -858,7 +844,7 @@ focus = {
 			add_ideas = ETH_lion_roar_focus
 		}
 	}
-	
+
 	focus = { #Call for end of war
 		id = ETH_demand_summit
 		#text = "Demand Summit of World Powers"
@@ -879,14 +865,14 @@ focus = {
 				has_war_with = ITA
 			}
 		}
-		prerequisite = { 
+		prerequisite = {
 			focus = ETH_lion_roar
-			}
+		}
 		icon = GFX_goal_generic_improve_relations
 		x = 8
 		y = 7
 		cost = 3
-		ai_will_do = {	factor = 10 }	
+		ai_will_do = { factor = 10 }
 		completion_reward = {
 			add_named_threat = { threat = -10 name = italo_ethiopian_war }
 			remove_ideas = second_italo_ethiopian_war
@@ -894,57 +880,49 @@ focus = {
 			remove_ideas = ETH_swedish_red_cross
 			remove_ideas = ETH_lion_roar_focus
 			add_ideas = ETH_lion_roar_focus_lesser
-			ITA = { 
+			ITA = {
 				add_opinion_modifier = { target = ETH modifier = large_decrease }
-				}
+			}
 			ETH = {
 				country_event = { id = ethiopia.1 days = 1 }
-				}
+			}
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
 	
 ## Post WAR
 
-focus = {
-		id = ETH_red_sea_focus 
-
+	focus = {
+		id = ETH_red_sea_focus
 		icon = GFX_goal_generic_navy_cruiser
 		#text = "Red Sea Focus"
-		
-		available = {
-			AND = {
-				559 = { is_owned_by = ETH }
-				550 = { is_owned_by = ETH }
-			}
-		} 
 		x = 18
 		y = 0
 		cost = 10
+
+		available = {
+			559 = { is_owned_by = ETH }
+			550 = { is_owned_by = ETH }
+		}
+
 		completion_reward = {
-			if = {
-				limit = { 550 = { is_owned_by = ETH } }
-				550 = {
-					add_extra_state_shared_building_slots = 2
-					add_building_construction = {
-							type = dockyard
-							level = 2
-							instant_build = yes
-							}
-					}
+			550 = {
+				add_extra_state_shared_building_slots = 2
+				add_building_construction = {
+					type = dockyard
+					level = 2
+					instant_build = yes
 				}
+			}
 			
-			if = {
-				limit = { 559 = { is_owned_by = ETH } }
-				559 = {
-					add_extra_state_shared_building_slots = 2
-					add_building_construction = {
-							type = dockyard
-							level = 2
-							instant_build = yes
-							}
-					}
+			559 = {
+				add_extra_state_shared_building_slots = 2
+				add_building_construction = {
+					type = dockyard
+					level = 2
+					instant_build = yes
 				}
+			}
 			
 			add_tech_bonus = {
 				name = POL_coastal_defense
@@ -958,29 +936,21 @@ focus = {
 
 ### Air DOCTRINE ###
 
-focus = {
+	focus = {
 		id = ETH_modern_airforce
 		icon = GFX_goal_generic_build_airforce
 		x = 23
 		y = 0
 		cost = 10
+
 		available = {
-			AND = {
-				559 = { is_owned_by = ETH }
-				550 = { is_owned_by = ETH }
-			}
-		} 
+			559 = { is_owned_by = ETH }
+			550 = { is_owned_by = ETH }
+		}
 		ai_will_do = {
 			factor = 10
 		}
 		
-		available = {
-			AND = {
-				559 = { is_owned_by = ETH }
-				550 = { is_owned_by = ETH }
-			}
-		} 
-
 		completion_reward = {
 			add_tech_bonus = {
 				name = air_bonus
@@ -996,7 +966,7 @@ focus = {
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
 
-focus = {
+	focus = {
 		id = ETH_airbase_eritea
 		prerequisite = { focus = ETH_modern_airforce }
 		icon = GFX_goal_generic_air_production
@@ -1014,7 +984,7 @@ focus = {
 				}
 				add_building_construction = {
 					type = anti_air_building
-					level = 1				
+					level = 1
 					instant_build = yes
 				}
 			}
@@ -1022,7 +992,7 @@ focus = {
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
 
-focus = {
+	focus = {
 		id = ETH_airbase_somalia
 		prerequisite = { focus = ETH_modern_airforce }
 		icon = GFX_goal_generic_air_production
@@ -1040,15 +1010,15 @@ focus = {
 				}
 				add_building_construction = {
 					type = anti_air_building
-					level = 1				
+					level = 1
 					instant_build = yes
 				}
 			}
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
-	
-focus = {
+
+	focus = {
 		id = ETH_develop_airforce
 		icon = GFX_goal_multiple_bombers
 		prerequisite = { focus = ETH_airbase_somalia }
@@ -1068,26 +1038,24 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
-	
 
-		
-	
+
 	## Develop SENGlia and eritrea
-	
-focus = {
+
+	focus = {
 		id = ETH_develop_eritrea
 		available = {
 			550 = { is_owned_by = ETH }
-		} 
+		}
 		#text = "Develop Eritrea"
-		prerequisite = { focus =  ETH_red_sea_focus }
+		prerequisite = { focus = ETH_red_sea_focus }
 		icon = GFX_goal_generic_position_armies
 		x = 16
 		y = 1
 		cost = 10
 		ai_will_do = {
 			factor = 10
-		}	
+		}
 		completion_reward = {
 			550 = {
 				add_building_construction = {
@@ -1095,32 +1063,30 @@ focus = {
 					level = 2
 					instant_build = yes
 				}
-			}
-			550 = {
+				add_extra_state_shared_building_slots = 2
+
 				add_building_construction = {
 					type = dockyard
 					level = 1
 					instant_build = yes
 				}
-				add_extra_state_shared_building_slots = 2
 				
 				add_building_construction = {
 					type = industrial_complex
 					level = 1
 					instant_build = yes
-					}
+				}
 			}
-			
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
-	
+
 	focus = {
-		id = ETH_fortify_eritrea 
+		id = ETH_fortify_eritrea
 		prerequisite = { focus = ETH_develop_eritrea }
 		available = {
 			550 = { is_owned_by = ETH }
-		} 
+		}
 		icon = GFX_goal_generic_construct_naval_dockyard
 		#text = "Red Sea Focus"
 		x = 16
@@ -1137,7 +1103,7 @@ focus = {
 				add_building_construction = {
 					type = naval_base
 					level = 1
-					province = 12766					
+					province = 12766
 					instant_build = yes
 				}
 				add_building_construction = {
@@ -1158,26 +1124,25 @@ focus = {
 					province = 8043
 					instant_build = yes
 				}
-				
 			}
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
-	
+
 	focus = {
 		id = ETH_develop_somalia
 		available = {
 			559 = { is_owned_by = ETH }
 		} 
 		#text = "Develop SENGlia"
-		prerequisite = { focus =  ETH_red_sea_focus }
+		prerequisite = { focus = ETH_red_sea_focus }
 		icon = GFX_goal_generic_position_armies
 		x = 20
 		y = 1
 		cost = 10
 		ai_will_do = {
 			factor = 10
-		}	
+		}
 		completion_reward = {
 			559 = {
 				add_building_construction = {
@@ -1185,26 +1150,24 @@ focus = {
 					level = 1
 					instant_build = yes
 				}
-			}
-			559 = {
+				add_extra_state_shared_building_slots = 2
+
 				add_building_construction = {
 					type = dockyard
 					level = 1
 					instant_build = yes
 				}
-				add_extra_state_shared_building_slots = 2
 				
 				add_building_construction = {
 					type = industrial_complex
 					level = 1
 					instant_build = yes
-					}
+				}
 			}
-			
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
-	
+
 	focus = {
 		id = ETH_fortify_somalia 
 		prerequisite = { focus = ETH_develop_somalia }
@@ -1246,15 +1209,15 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
-	
+
 	focus = {
 		id = ETH_modern_navy
 		icon = GFX_goal_generic_construct_naval_dockyard
 		x = 18
 		y = 3
 		cost = 10
-		prerequisite = { focus = ETH_fortify_somalia  }
-		prerequisite = { focus = ETH_fortify_eritrea  }
+		prerequisite = { focus = ETH_fortify_somalia }
+		prerequisite = { focus = ETH_fortify_eritrea }
 		ai_will_do = {
 			factor = 10
 		}
@@ -1272,7 +1235,7 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
-	
+
 	focus = {
 		id = ETH_amphibious_operations
 		icon = GFX_goal_generic_amphibious_assault
@@ -1285,7 +1248,7 @@ focus = {
 		#}
 
 		available_if_capitulated = yes
-		
+
 		completion_reward = {
 			add_tech_bonus = {
 				bonus = 1
@@ -1295,7 +1258,7 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
-	
+
 	focus = {
 		id = ETH_carrier_primacy
 		icon = GFX_goal_generic_navy_carrier
@@ -1320,7 +1283,7 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
-	
+
 	focus = {
 		id = ETH_battleship_primacy
 		icon = GFX_goal_generic_navy_battleship
@@ -1344,57 +1307,31 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
-	
+
 	############ Foreign wars ##########
-	
+
 	focus = {
 		id = ETH_reclaim_aksum
 		available = {
 			r56_script_i_am_sane = yes
-			OR = {
-				if = {
-					limit = {
-						YEM = {
-							exists = yes
-						}
-					}
-					YEM = {
-						r56_script_target_is_sane = yes
-					}
-				}
-				if = {
-					limit = {
-						ENG = {
-							exists = yes
-						}
-					}
-					ENG = {
-						r56_script_target_is_sane = yes
-					}
-				}
+			293 = {
+				OWNER = { r56_script_target_is_sane = yes }
+			}
+			659 = {
+				OWNER = { r56_script_target_is_sane = yes }
 			}
 		}
 		bypass = {
-			AND = {
-				if = {
-					limit = {
-						YEM = {
-							exists = yes
-						}
-					}
-					YEM = {
-						r56_script_standard_bypass = yes
-					}
+			293 = {
+				OR = {
+					OWNER = { r56_script_standard_bypass = yes }
+					is_owned_by = ETH
 				}
-				if = {
-					limit = {
-						ENG = {
-							exists = yes
-						}
-					}
-					ENG = {
-						r56_script_standard_bypass = yes
-					}
+			}
+			659 = {
+				OR = {
+					OWNER = { r56_script_standard_bypass = yes }
+					is_owned_by = ETH
 				}
 			}
 		}
@@ -1413,68 +1350,91 @@ focus = {
 				}
 				factor = 0
 			}
-		}	
+		}
+
 		completion_reward = {
 			add_state_core = 293
 			add_state_core = 659
-			if = {
+			if = { #Both under the same nation.
 				limit = {
-					YEM = {
-						r56_script_target_is_sane = yes
-						owns_state = 293
-						NOT = {
+					293 = {
+						owner = {
+							r56_script_target_is_sane = yes
 							owns_state = 659
+							NOT = { tag = ROOT } #Not us. Just in case.
 						}
 					}
 				}
-				create_wargoal = {
-					type = take_state_focus
-					target = YEM
-					expire = 0
-					generator = { 293 }
-				} 
+				293 = {
+					owner = {
+						ROOT = {
+							create_wargoal = {
+								type = take_state_focus
+								target = PREV
+								expire = 0
+								generator = { 293 659 }
+							} 
+						}
+					}
+				}
 			}
-			if = {
-				limit = {
-					YEM = {
-						r56_script_target_is_sane = yes
-						owns_state = 293
-						owns_state = 659
-						
+			else = { #Otherwise, check this.
+				if = {
+					limit = {
+						293 = {
+							owner = {
+								r56_script_target_is_sane = yes
+								NOT = { tag = ROOT } #Not us.
+							}
+						}
+					}
+					293 = {
+						owner = {
+							ROOT = {
+								create_wargoal = {
+									type = take_state_focus
+									target = PREV
+									expire = 0
+									generator = { 293 }
+								} 
+							}
+						}
 					}
 				}
-				create_wargoal = {
-					type = take_state_focus
-					target = YEM
-					expire = 0
-					generator = { 293 659 }
-				} 
-			}			
-			if = {
-				limit = {
-					ENG = {
-						r56_script_target_is_sane = yes
-						owns_state = 659
+				if = {
+					limit = {
+						659 = {
+							owner = {
+								r56_script_target_is_sane = yes
+								NOT = { tag = ROOT } #Not us.
+							}
+						}
+					}
+					659 = {
+						owner = {
+							ROOT = {
+								create_wargoal = {
+									type = take_state_focus
+									target = PREV
+									expire = 0
+									generator = { 659 }
+								} 
+							}
+						}
 					}
 				}
-				create_wargoal = {
-					type = take_state_focus
-					target = ENG
-					expire = 0
-					generator = { 659 }
-				} 
 			}
 		}
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 	}
-	
+
 	focus = {
 		id = ETH_death_to_saudis
 		bypass = {
 			SAU = { exists = no }
 		}
 		#text = "Saudi Issue"
-		prerequisite = { focus =  ETH_reclaim_aksum }
+		prerequisite = { focus = ETH_reclaim_aksum }
 		available = {
 			r56_script_i_am_sane = yes
 			SAU = {
@@ -1482,13 +1442,13 @@ focus = {
 			}
 			OR = {
 				293 = { is_owned_by = ETH }
-				YEM = { has_capitulated = yes }
+				293 = { owner = { has_capitulated = yes } }
 			}
 			OR = {
-				ENG = { has_capitulated = yes }
+				659 = { owner = { has_capitulated = yes } }
 				659 = { is_owned_by = ETH }
 			}
-		} 
+		}
 		bypass = {
 			SAU = {
 				r56_script_standard_bypass = yes
@@ -1522,45 +1482,42 @@ focus = {
 					}
 				}
 			}
-			
 		}
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 	}
-	
-	
-	
+
 	focus = {
 		id = ETH_demand_french_somalia
 		#text = "Demand French SENGlia"
 		will_lead_to_war_with = YEM
-		prerequisite = { focus =  ETH_reclaim_aksum }
+		prerequisite = { focus = ETH_reclaim_aksum }
 		icon = GFX_goal_generic_occupy_states_ongoing_war
 		x = 6
 		y = 9
 		cost = 10
 		ai_will_do = {
 			factor = 10
-		}	
+		}
 		available = {
 			r56_script_i_am_sane = yes
 			268 = {
 				OWNER = {
 					r56_script_target_is_sane = yes
-				}				
+				}
 			}
 		}
 		bypass = {
 			268 = {
 				OWNER = {
 					r56_script_standard_bypass = yes
-				}				
+				}
 			}
 		}
 		completion_reward = {
 			268 = {
 				OWNER = {
 					add_opinion_modifier = { target = ROOT modifier = small_decrease }
-				}				
+				}
 			}
 			ETH = { country_event = { id = ethiopia.1008 days = 1 } }
 			add_state_core = 268
@@ -1584,84 +1541,106 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 	}
-	
+
 	focus = {
 		id = ETH_demand_british_somalia
 		#text = "Demand British SENGlia"
-		prerequisite = { focus =  ETH_reclaim_aksum }
+		prerequisite = { focus = ETH_reclaim_aksum }
 		icon = GFX_goal_generic_occupy_states_ongoing_war
 		x = 10
 		y = 9
 		cost = 10
 		ai_will_do = {
 			factor = 10
-		}	
+		}
 		available = {
 			r56_script_i_am_sane = yes
 			269 = {
 				OWNER = {
 					r56_script_target_is_sane = yes
-				}				
+				}
 			}
 		}
 		bypass = {
 			269 = {
 				OWNER = {
 					r56_script_standard_bypass = yes
-				}				
+				}
 			}
 		}
 		completion_reward = {
 			269 = {
 				OWNER = {
 					add_opinion_modifier = { target = ROOT modifier = small_decrease }
-				}				
+				}
 			}
 			ETH = { country_event = { id = ethiopia.1007 days = 1 } }
 			add_state_core = 269
 			add_state_core = 658
-			269 = {
-				OWNER = {
-					ROOT = {
-						create_wargoal = {
-							target = PREV
-							expire = 0
-							type = take_state_focus
-							generator = { 269 }
-						}
-						add_ai_strategy = {
-							type = conquer
-							id = PREV
-							value = 200
+			if = {
+				limit = { 269 = { owner = { owns_state = 658 } } }
+				269 = {
+					OWNER = {
+						ROOT = {
+							create_wargoal = {
+								target = PREV
+								expire = 0
+								type = take_state_focus
+								generator = { 269 658 }
+							}
+							add_ai_strategy = {
+								type = conquer
+								id = PREV
+								value = 200
+							}
 						}
 					}
 				}
 			}
-			658 = {
-				OWNER = {
-					ROOT = {
-						create_wargoal = {
-							target = PREV
-							expire = 0
-							type = take_state_focus
-							generator = { 658 }
-						}
-						add_ai_strategy = {
-							type = conquer
-							id = PREV
-							value = 200
+			else = {
+				269 = {
+					OWNER = {
+						ROOT = {
+							create_wargoal = {
+								target = PREV
+								expire = 0
+								type = take_state_focus
+								generator = { 269 }
+							}
+							add_ai_strategy = {
+								type = conquer
+								id = PREV
+								value = 200
+							}
 						}
 					}
 				}
-			}			
+				658 = {
+					OWNER = {
+						ROOT = {
+							create_wargoal = {
+								target = PREV
+								expire = 0
+								type = take_state_focus
+								generator = { 658 }
+							}
+							add_ai_strategy = {
+								type = conquer
+								id = PREV
+								value = 200
+							}
+						}
+					}
+				}
+			}
 		}
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 	}
-	
+
 	focus = {
 		id = ETH_demand_solomon_kingdom
 		#text = "Demand Solomonic Kingdom"
-		prerequisite = { focus =  ETH_death_to_saudis}
+		prerequisite = { focus = ETH_death_to_saudis}
 		prerequisite = { focus = ETH_demand_british_somalia}
 		icon = GFX_goal_ETH_kingdom_of_judah
 		x = 9
@@ -1675,13 +1654,22 @@ focus = {
 			453 = {
 				OWNER = {
 					r56_script_target_is_sane = yes
-				}				
+				}
 			}
 		}
-		bypass = {
 
-		}
+		bypass = { }
+
 		completion_reward = {
+			every_state = {
+				limit = {
+					OR = { is_core_of = PAL is_core_of = JOR state = 453 }
+					NOT = { is_owned_by = ROOT } 
+				}
+				add_claim_by = ETH
+			}
+
+ #Special case: ENG has them all
 			if = {
 				limit = {
 					ENG = {
@@ -1692,183 +1680,154 @@ focus = {
 						owns_state = 455
 					}
 				}
-				ENG = {	add_opinion_modifier = { target = ETH modifier = large_decrease } }
-				ETH = {	add_opinion_modifier = { target = ENG modifier = large_decrease } }
-				ETH = { country_event = { id = ethiopia.1009 days = 1 } }
-				add_state_claim = 453
-				add_state_claim = 454
-				add_state_claim = 830
-				add_state_claim = 831
-				add_state_claim = 455
+				ENG = { add_opinion_modifier = { target = ETH modifier = large_decrease } }
+				ETH = { add_opinion_modifier = { target = ENG modifier = large_decrease } }
 				create_wargoal = {
 					type = take_state_focus
 					target = ENG
 					expire = 0
 					generator = { 453 454 830 831 455 }
-				}				
+				}
 			}
 			else = {
 				if = {
 					limit = {
-						NOT = {
-							owns_state = 453
+						NOT = { owns_state = 453 }
+					}
+					453 = {
+						OWNER = {
+							add_opinion_modifier = { target = ROOT modifier = small_decrease }
 						}
-						453 = {
-							OWNER = {
-								add_opinion_modifier = { target = ROOT modifier = small_decrease }
-							}				
-						}
-						453 = {
-							OWNER = {
-								ROOT = {
-									create_wargoal = {
-										target = PREV
-										expire = 0
-										type = take_state_focus
-										generator = { 453 }
-									}
-									add_ai_strategy = {
-										type = conquer
-										id = PREV
-										value = 200
-									}
+					}
+					453 = {
+						OWNER = {
+							ROOT = {
+								create_wargoal = {
+									target = PREV
+									expire = 0
+									type = take_state_focus
+									generator = { 453 }
+								}
+								add_ai_strategy = {
+									type = conquer
+									id = PREV
+									value = 200
 								}
 							}
 						}
-						add_state_claim = 453												
 					}
 				}
 				if = {
 					limit = {
-						NOT = {
-							owns_state = 454
+						NOT = { owns_state = 454 }
+					}
+					454 = {
+						OWNER = {
+							add_opinion_modifier = { target = ROOT modifier = small_decrease }
 						}
-						454 = {
-							OWNER = {
-								add_opinion_modifier = { target = ROOT modifier = small_decrease }
-							}				
-						}
-						454 = {
-							OWNER = {
-								ROOT = {
-									create_wargoal = {
-										target = PREV
-										expire = 0
-										type = take_state_focus
-										generator = { 454 }
-									}
-									add_ai_strategy = {
-										type = conquer
-										id = PREV
-										value = 200
-									}
+					}
+					454 = {
+						OWNER = {
+							ROOT = {
+								create_wargoal = {
+									target = PREV
+									expire = 0
+									type = take_state_focus
+									generator = { 454 }
+								}
+								add_ai_strategy = {
+									type = conquer
+									id = PREV
+									value = 200
 								}
 							}
 						}
-						add_state_claim = 454												
 					}
 				}
 				if = {
 					limit = {
-						NOT = {
-							owns_state = 830
+						NOT = { owns_state = 830 }
+					}
+					830 = {
+						OWNER = {
+							add_opinion_modifier = { target = ROOT modifier = small_decrease }
 						}
-						830 = {
-							OWNER = {
-								add_opinion_modifier = { target = ROOT modifier = small_decrease }
-							}				
-						}
-						830 = {
-							OWNER = {
-								ROOT = {
-									create_wargoal = {
-										target = PREV
-										expire = 0
-										type = take_state_focus
-										generator = { 830 }
-									}
-									add_ai_strategy = {
-										type = conquer
-										id = PREV
-										value = 200
-									}
+					}
+					830 = {
+						OWNER = {
+							ROOT = {
+								create_wargoal = {
+									target = PREV
+									expire = 0
+									type = take_state_focus
+									generator = { 830 }
+								}
+								add_ai_strategy = {
+									type = conquer
+									id = PREV
+									value = 200
 								}
 							}
 						}
-						add_state_claim = 830												
 					}
 				}
 				if = {
 					limit = {
-						NOT = {
-							owns_state = 831
+						NOT = { owns_state = 831 }
+					}
+					831 = {
+						OWNER = {
+							add_opinion_modifier = { target = ROOT modifier = small_decrease }
 						}
-						831 = {
-							OWNER = {
-								add_opinion_modifier = { target = ROOT modifier = small_decrease }
-							}				
-						}
-						831 = {
-							OWNER = {
-								ROOT = {
-									create_wargoal = {
-										target = PREV
-										expire = 0
-										type = take_state_focus
-										generator = { 831 }
-									}
-									add_ai_strategy = {
-										type = conquer
-										id = PREV
-										value = 200
-									}
+					}
+					831 = {
+						OWNER = {
+							ROOT = {
+								create_wargoal = {
+									target = PREV
+									expire = 0
+									type = take_state_focus
+									generator = { 831 }
+								}
+								add_ai_strategy = {
+									type = conquer
+									id = PREV
+									value = 200
 								}
 							}
 						}
-						add_state_claim = 831												
 					}
 				}
 				if = {
 					limit = {
-						NOT = {
-							owns_state = 455
+						NOT = { owns_state = 455 }
+					}
+					455 = {
+						OWNER = {
+							add_opinion_modifier = { target = ROOT modifier = small_decrease }
 						}
-						455 = {
-							OWNER = {
-								add_opinion_modifier = { target = ROOT modifier = small_decrease }
-							}				
-						}
-						831 = {
-							OWNER = {
-								ROOT = {
-									create_wargoal = {
-										target = PREV
-										expire = 0
-										type = take_state_focus
-										generator = { 455 }
-									}
-									add_ai_strategy = {
-										type = conquer
-										id = PREV
-										value = 200
-									}
+					}
+					831 = {
+						OWNER = {
+							ROOT = {
+								create_wargoal = {
+									target = PREV
+									expire = 0
+									type = take_state_focus
+									generator = { 455 }
+								}
+								add_ai_strategy = {
+									type = conquer
+									id = PREV
+									value = 200
 								}
 							}
 						}
-						add_state_claim = 455												
 					}
-				}																			
-				ETH = { country_event = { id = ethiopia.1009 days = 1 } }															
+				}
 			}
+			ETH = { country_event = { id = ethiopia.1009 days = 1 } }
 		}
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 	}
 }
-	
-	
-	
-
-	
-
-	
-	


### PR DESCRIPTION
The focus ETH_modern_airforce had a duplicated available section.
Rewritten focus ETH_reclaim_aksum to survive in case of unexpected owners of Adan/Yemen.
Small modification to ETH_death_to_saudis to account for the changes on ETH_reclaim_aksum. 
Removed redundant "If" from ETH_red_sea_focus. It's already required, so it has to be true.
Made a little check to ETH_demand_british_somalia to avoid 2 different conquest war goals against the same country.
The focus ETH_demand_solomon_kingdom had some misplaced }. This resulted in a bunch of errors and more importantly, the focus didn't work if ENG wasn't the owner of the Levant.
Formatting.
Removed redundant "AND" from some sections.
Added bypass to the Christmas Offensive and National Mobilization in case the war with Italy ended for some bizarre reason before those focus were taken, mostly cause all the conquest focus are gated behind these. There's still an issue with the support focuses (war with Italy required), but it's a start.

Not fixed is the missing localization for the idea ETH_the_long_lance, given by the focus "The Long Lance".