### PR TITLE
Sanity checks: Brazil

### DIFF
--- a/common/national_focus/brazil.txt
+++ b/common/national_focus/brazil.txt
@@ -52,7 +52,7 @@ focus_tree = {
 			factor = 10
 		}
 		completion_reward = {
-			add_ideas = bra_national_security_law_idea 	
+			add_ideas = bra_national_security_law_idea
 		}
 		search_filters = { FOCUS_FILTER_STABILITY }
 	}
@@ -62,16 +62,16 @@ focus_tree = {
 		prerequisite = { focus = bra_a_voz_do_brasil }
 		x = 9
 		y = 1
-		bypass = { 
+		bypass = {
 		NOT = { has_idea = bra_1930 }
 		}
 		relative_position_id = bra_a_voz_do_brasil
 		cost = 5
 		completion_reward = {
-			if = { 
+			if = {
 				limit = {
-				has_idea = bra_1930
-				 }
+					has_idea = bra_1930
+				}
 			swap_ideas = { remove_idea = bra_1930 add_idea = bra_1930_2 }
 			}
 		}
@@ -86,7 +86,7 @@ focus_tree = {
 		cost = 5
 		completion_reward = {
 			army_experience = 10
-			add_ideas = bra_consegnac_idea 
+			add_ideas = bra_consegnac_idea
 		}
 	}
 	focus = {
@@ -95,7 +95,7 @@ focus_tree = {
 		prerequisite = { focus = bra_national_security_law }
 		x = 0
 		y = 2
-		relative_position_id = bra_a_voz_do_brasil 
+		relative_position_id = bra_a_voz_do_brasil
 		cost = 10
 		ai_will_do = {
 			factor = 25
@@ -114,11 +114,9 @@ focus_tree = {
 		prerequisite = { focus = bra_polaca }
 		mutually_exclusive = { focus = bra_populism }
 		mutually_exclusive = { focus = bra_federalism }
-		available = { 
-			AND = {
-				has_government = neutrality
-				has_idea = bra_instabilidade
-			}
+		available = {
+			has_government = neutrality
+			has_idea = bra_instabilidade
 		}
 		x = 0
 		y = 1
@@ -163,7 +161,7 @@ focus_tree = {
 				factor = 1
 			}
 		}
-		available = { 
+		available = {
 			AND = {
 				OR = {
 					has_government = neutrality
@@ -253,7 +251,7 @@ focus_tree = {
 			}
 		}
 		cost = 10
-		available = { 
+		available = {
 			AND = {
 				NOT = {
 					has_government = communism
@@ -352,7 +350,7 @@ focus_tree = {
 		relative_position_id = bra_quereismo
 		x = 0
 		y = 1
-		cost = 5		
+		cost = 5
 		ai_will_do = {
 			factor = 25
 		}
@@ -429,18 +427,18 @@ focus_tree = {
 		relative_position_id = bra_tecnocratic_reform
 		cost = 10
 		completion_reward = {
-				if = {
-						limit = { 
-								has_idea = bra_1930_2 
-								}
-					remove_ideas = bra_1930_2
-					}
-				if = {
-						limit = { 
-								has_idea = bra_1930
-								}
-					remove_ideas = bra_1930
-					}
+			if = {
+				limit = {
+					has_idea = bra_1930_2
+				}
+				remove_ideas = bra_1930_2
+			}
+			if = {
+				limit = {
+					has_idea = bra_1930
+				}
+				remove_ideas = bra_1930
+			}
 			hidden_effect = {
 					if = { limit = { BRA = { has_government = fascism } }
 					hidden_effect = {
@@ -644,7 +642,8 @@ focus_tree = {
             set_province_name = { id = 5208 name = "Brasília"}
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
-	}	
+	}
+
 	focus = {
 		id = bra_tiro_de_guerra
 		icon = GFX_goal_generic_military_sphere
@@ -655,52 +654,39 @@ focus_tree = {
 		cost = 10
 		completion_reward = {
 			if = {
-				limit = {
-					has_government = neutrality
-					NOT = { has_completed_focus = bra_monarquia_focus }
+				limit = { has_completed_focus = bra_monarquia_focus }
+				if = {
+					limit = { has_government = neutrality }
+					swap_ideas = { remove_idea = bra_antropofagia add_idea = bra_antropofagia_imperial_neutra }
 				}
-				swap_ideas = { remove_idea = bra_antropofagia_neu_2 add_idea = bra_antropofagia_neu_3 }
-			}
-			if = {
-				limit = {
-					has_government = fascism
-					NOT = { has_completed_focus = bra_monarquia_focus }
+				else_if = {
+					limit = { has_government = fascism }
+					swap_ideas = { remove_idea = bra_antropofagia add_idea = bra_antropofagia_imperial_fascista }
 				}
-				swap_ideas = { remove_idea = bra_antropofagia_fasc_2 add_idea = bra_antropofagia_fasc_3 }
 			}
-			if = { 
-				limit = {
-					has_government = democratic
-					NOT = { has_completed_focus = bra_monarquia_focus }
+			else = {
+				if = {
+					limit = { has_government = neutrality }
+					swap_ideas = { remove_idea = bra_antropofagia_neu_2 add_idea = bra_antropofagia_neu_3 }
 				}
-				swap_ideas = { remove_idea = bra_antropofagia_dem_2 add_idea = bra_antropofagia_dem_3 }
-			}
-			if = { 
-				limit = {
-					has_government = communism
-					NOT = { has_completed_focus = bra_monarquia_focus }
+				else_if = {
+					limit = { has_government = fascism }
+					swap_ideas = { remove_idea = bra_antropofagia_fasc_2 add_idea = bra_antropofagia_fasc_3 }
 				}
-				swap_ideas = { remove_idea = bra_antropofagia_com_2 add_idea = bra_antropofagia_com_3 }
-			}
-			if = { 
-				limit = {
-					has_government = neutrality
-					has_completed_focus = bra_monarquia_focus
+				else_if = {
+					limit = { has_government = democratic }
+					swap_ideas = { remove_idea = bra_antropofagia_dem_2 add_idea = bra_antropofagia_dem_3 }
 				}
-				swap_ideas = { remove_idea = bra_antropofagia add_idea = bra_antropofagia_imperial_neutra }
-			}
-			if = { 
-				limit = {
-					has_government = fascism
-					has_completed_focus = bra_monarquia_focus
+				else = {
+					swap_ideas = { remove_idea = bra_antropofagia_com_2 add_idea = bra_antropofagia_com_3 }
 				}
-				swap_ideas = { remove_idea = bra_antropofagia add_idea = bra_antropofagia_imperial_fascista }
 			}
+
 			if = {
 				limit = { has_government = communism }
 				create_field_marshal = {
 					name = "Luís Carlos Prestes"
-					picture = "gfx/leaders/BRA/r56_Portrait_BRA_Field_Marshall_Prestes.dds"
+					picture = "gfx/leaders/South America/Portrait_South_America_Generic_land_1.dds"
 					traits = { politically_connected }
 					skill = 3
 					
@@ -748,7 +734,6 @@ focus_tree = {
 		cost = 5
 		
 		completion_reward = {
-
 			add_tech_bonus = {
 				name = industrial_bonus
 				bonus = 0.5
@@ -758,6 +743,7 @@ focus_tree = {
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
+
 	focus = {
 		id = bra_federal_institutes
 		icon = GFX_focus_generic_cryptologic_bomb
@@ -863,7 +849,7 @@ focus_tree = {
 					bonus = 0.5
 					uses = 1
 					category = electronics
-				}	
+				}
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
@@ -873,7 +859,7 @@ focus_tree = {
 		prerequisite = { focus = bra_more_federal_universities }
 		relative_position_id = bra_more_federal_universities
 		x = 0
-		y = 1		
+		y = 1
 		available = {
 			num_of_factories > 75
 		}
@@ -917,7 +903,7 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
-###-----> Navy Branch <><> <><> <><> <><> 
+###-----> Navy Branch <><> <><> <><> <><>
 	focus = {
 		id = bra_belem_porto
 		icon = GFX_goal_BRA_coa_navy
@@ -934,19 +920,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
@@ -991,7 +972,7 @@ focus = {
 				attack_skill = 1
 				defense_skill = 2
 				maneuvering_skill = 3
-				coordination_skill = 1					
+				coordination_skill = 1
 			}
 			add_tech_bonus = {
 				name = BRA_naval_doctrine
@@ -1058,7 +1039,7 @@ focus = {
 			498 = { add_building_construction = { type = dockyard level = 1 instant_build = yes } }
 		}
 	}
-###-----> Army Branch <><> <><> <><> <><> 
+###-----> Army Branch <><> <><> <><> <><>
 	focus = {
 		id = bra_ana_guerra_civil
 		icon = GFX_goal_consitution
@@ -1077,7 +1058,7 @@ focus = {
 			}
 			hidden_effect = {
 				load_oob = BRA_cohen
-			}	
+			}
 			custom_effect_tooltip =  bra_tropas_1932_tooltip
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH FOCUS_FILTER_MANPOWER }
@@ -1276,8 +1257,8 @@ focus = {
 			swap_ideas = { remove_idea = bra_ana_paulista_idea_3  add_idea = bra_ana_paulista_idea_4 }
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
-	}	
-###-----> Air Branch <><> <><> <><> <><> 
+	}
+###-----> Air Branch <><> <><> <><> <><>
 	focus = {
 		id = bra_modernizacao_aerea
 		icon = GFX_goal_BRA_coa_air_force
@@ -1294,7 +1275,7 @@ focus = {
 					level = 1
 					instant_build = yes
 				}
-			} 
+			}
 			random_owned_controlled_state = {
 				prioritize = { 280 }
 				add_building_construction = {
@@ -1421,7 +1402,7 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}
-###-----> Industry Branch <><> <><> <><> <><> 
+###-----> Industry Branch <><> <><> <><> <><>
 	focus = {
 		id = bra_CTEF_CLT
 		icon = GFX_goal_generic_positive_trade_relations
@@ -1452,7 +1433,7 @@ focus = {
 				}
 				add_extra_state_shared_building_slots = 1
 				
-			}			
+			}
 			500 = {
 				add_building_construction = {
 					type = industrial_complex
@@ -1460,7 +1441,7 @@ focus = {
 					instant_build = yes
 				}
 				add_extra_state_shared_building_slots = 1
-			}			
+			}
 			496 = {
 				add_building_construction = {
 					type = industrial_complex
@@ -1472,19 +1453,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
@@ -1540,19 +1516,14 @@ focus = {
 			}
 		if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
@@ -1574,19 +1545,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
@@ -1607,26 +1573,21 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
 		}
-	}	
+	}
 	focus = {
 		id = bra_cmsp
 		icon = GFX_focus_generic_the_giant_wakes
@@ -1648,19 +1609,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
@@ -1699,19 +1655,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
@@ -1736,42 +1687,42 @@ focus = {
 					instant_build = yes
 				}
 			}
-			501 = { 
+			501 = {
 				add_building_construction = {
 					type = infrastructure
 					level = 1
 					instant_build = yes
 				}
 			}
-			499 = { 
+			499 = {
 				add_building_construction = {
 					type = infrastructure
 					level = 1
 					instant_build = yes
 				}
 			}
-			496 = { 
+			496 = {
 				add_building_construction = {
 					type = infrastructure
 					level = 1
 					instant_build = yes
 				}
 			}
-			498 = { 
+			498 = {
 				add_building_construction = {
 					type = infrastructure
 					level = 1
 					instant_build = yes
 				}
 			}
-			502 = { 
+			502 = {
 				add_building_construction = {
 					type = infrastructure
 					level = 1
 					instant_build = yes
 				}
 			}
-			503 = { 
+			503 = {
 				add_building_construction = {
 					type = infrastructure
 					level = 1
@@ -1781,19 +1732,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 70
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 70
@@ -1861,25 +1807,19 @@ focus = {
 			}
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 5
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 5
 				}
 			}
-			
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
@@ -1903,24 +1843,19 @@ focus = {
 			}
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
-			}	
+			}
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
@@ -1942,21 +1877,16 @@ focus = {
 					instant_build = yes
 				}
 			}
-		if = {
+			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
@@ -1964,7 +1894,7 @@ focus = {
 			}
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
-	}	
+	}
 	focus = {
 		id = bra_itabira
 		icon = GFX_goal_generic_construction2
@@ -1978,19 +1908,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
@@ -2015,19 +1940,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
@@ -2036,6 +1956,7 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
+
 	focus = {
 		id = bra_salte
 		icon = GFX_goal_generic_national_unity
@@ -2065,19 +1986,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
@@ -2102,19 +2018,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
@@ -2133,7 +2044,7 @@ focus = {
 		y = 1
 		cost = 10
 		completion_reward = {
-		add_ideas = { bra_bb_idea }
+			add_ideas = { bra_bb_idea }
 		}
 	}
 	
@@ -2159,19 +2070,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 50
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 50
@@ -2202,8 +2108,7 @@ focus = {
 				effect_tooltip = {
 					random_owned_controlled_state = {
 						prioritize = { 502 }
-						limit = {
-						}
+						limit = { }
 						add_extra_state_shared_building_slots = 1
 						add_building_construction = {
 							type = synthetic_refinery
@@ -2224,8 +2129,7 @@ focus = {
 					effect_tooltip = {
 					random_owned_controlled_state = {
 						prioritize = { 502 }
-						limit = {
-						}
+						limit = { }
 						add_extra_state_shared_building_slots = 1
 						add_building_construction = {
 							type = synthetic_refinery
@@ -2239,19 +2143,14 @@ focus = {
 			}
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
@@ -2269,9 +2168,9 @@ focus = {
 		relative_position_id = bra_bb
 		x = 1
 		y = 1
-		available = { 
-			AND = { 
-				has_completed_focus = bra_fiesp 
+		available = {
+			AND = {
+				has_completed_focus = bra_fiesp
 				has_idea = bra_eficiencia_4
 			}
 		}
@@ -2324,7 +2223,7 @@ focus = {
 			add_research_slot = 1
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
-	}	
+	}
 	focus = {
 		id = bra_zfm
 		icon = GFX_goal_generic_construct_civilian
@@ -2345,19 +2244,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 35
@@ -2366,16 +2260,16 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_INDUSTRY }
 	}
-	
+
 	focus = {
 		id = bra_diplomacia
 		icon = GFX_goal_generic_intelligence_exchange
 		x = 21
 		y = 0
-		ai_will_do = { 
+		ai_will_do = {
 			factor = 1
 		}
-		available = { 
+		available = {
 			OR = {
 				has_completed_focus = bra_2_prestes_column
 				has_completed_focus = bra_quereismo
@@ -2389,7 +2283,7 @@ focus = {
 			custom_effect_tooltip = bra_diplomacia_tooltip
 		}
 	}
-	
+
 	focus = {
 		id = bra_amigo_eua
 		icon = GFX_goal_generic_improve_relations
@@ -2399,7 +2293,7 @@ focus = {
 		available = { OR = { has_government = neutrality has_government = democratic } }
 		relative_position_id = bra_diplomacia
 		bypass = {
-		is_in_faction_with = SOV
+			is_in_faction_with = SOV
 		}
 		x = -2
 		y = 1
@@ -2411,7 +2305,7 @@ focus = {
 			USA = { add_opinion_modifier = { target = BRA modifier = bra_amigo_outro_modifier } }
 		}
 	}
-	
+
 	focus = {
 		id = bra_amigo_aliados
 		icon = GFX_goal_support_democracy
@@ -2424,32 +2318,43 @@ focus = {
 		cost = 5
 		ai_will_do = {
 			factor = 1
+			modifier = {
+				OR = {
+					ENG = { is_subject = yes }
+					NOT = { ENG = { has_government = democratic } }
+				}
+				factor = 0
+			}
 		}
-		available = { 
-			OR = { 
+		available = {
+			is_subject = no
+			OR = {
 				has_government = democratic
 				has_government = neutrality
-			} 
+			}
 		}
 		completion_reward = {
 			add_political_power = 75
-			add_opinion_modifier = { target = ENG modifier = bra_amigo_modifier }
-			ENG = { add_opinion_modifier = { target = BRA modifier = bra_amigo_outro_modifier } }
-			
 			every_other_country = {
 				limit = {
 					is_in_faction_with = ENG
 				}
-				add_opinion_modifier = { 
-					target = BRA 
-					modifier = bra_amigo_outro_modifier 
+				add_opinion_modifier = {
+					target = BRA
+					modifier = bra_amigo_outro_modifier
+				}
+#				BRA = { add_opinion_modifier = { target = PREV modifier = bra_amigo_outro_modifier } } #Added for consistency.
+			}
+			hidden_effect = {
+				every_other_country = {
+					limit = { is_in_faction_with = ENG }
+					BRA = { add_opinion_modifier = { target = PREV modifier = bra_amigo_outro_modifier } } #Moved to hidden due to an UI problem: It suggests that UK gets the benefit.
 				}
 			}
-		
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
 	}
-	
+
 	focus = {
 		id = bra_mercosul_focus
 		icon = GFX_goal_generic_positive_trade_relations
@@ -2463,47 +2368,37 @@ focus = {
 		ai_will_do = {
 			factor = 1
 		}
-		available = { OR = { has_government = democratic has_government = neutrality  } }
+		available = { OR = { has_government = democratic has_government = neutrality } is_subject = no }
 		completion_reward = {
 			every_other_country = {
 				limit = {
-					OR= {
-						AND = {
-							capital_scope = { is_on_continent = south_america }
-							OR = { 
-								has_government = democratic
-								has_government = neutrality
-							}
-							NOT = { tag = BRA }
-						}
+					capital_scope = { is_on_continent = south_america }
+					OR = {
+						has_government = democratic
+						has_government = neutrality
 					}
 				}
-				add_opinion_modifier = { 
-					target = BRA 
+				add_opinion_modifier = {
+					target = BRA
 					modifier = bra_comercio_mercosul_modifier
 				}
 			}
 			every_other_country = {
 				limit = {
-					OR= {
-						AND = {
-							capital_scope = { is_on_continent = south_america }
-							OR = { 
-								has_government = democratic
-								has_government = neutrality
-							}
-							NOT = { tag = BRA }
-						}
+					capital_scope = { is_on_continent = south_america }
+					OR = {
+						has_government = democratic
+						has_government = neutrality
 					}
 				}
-				add_opinion_modifier = { 
-					target = BRA 
+				add_opinion_modifier = {
+					target = BRA
 					modifier = bra_amigo_modifier
 				}
 			}
 		}
 	}
-	
+
 	focus = {
 		id = bra_transatlantico
 		icon = GFX_goal_generic_defence
@@ -2514,7 +2409,14 @@ focus = {
 		x = 2
 		y = 1
 		cost = 5
-		available = { has_government = neutrality }
+		allow_branch = { #This is a sanity check.
+			is_subject = no
+			OR = {
+				ARG = { exists = yes is_subject = no }
+				POR = { exists = yes is_subject = no }
+			}
+		}
+		available = { has_government = neutrality is_in_faction = no }
 		ai_will_do = {
 			factor = 0
 		}
@@ -2540,95 +2442,29 @@ focus = {
 		cost = 5
 		completion_reward = {
 			add_political_power = 75
-			add_opinion_modifier = { target = ENG modifier = bra_comercio_modifier }
-			if = {
-				limit = { 
-					RAJ = { 
-						AND = { 
-							is_in_faction_with = ENG 
-							OR = { 
-								has_government = neutrality
-								has_government = democratic
-							}
-						}
+			every_other_country = { # RAJ SAF AST NZL CAN MAL
+				limit = {
+					is_in_faction_with = ENG
+					OR = {
+						has_government = neutrality
+						has_government = democratic
+					}
+					OR = {
+						original_tag = AST
+						original_tag = CAN
+						original_tag = MAL
+						original_tag = NZL
+						original_tag = RAJ
+						original_tag = SAF
+						is_subject_of = ENG
 					}
 				}
-				add_opinion_modifier = { target = RAJ modifier = bra_comercio_modifier }
-			}
-			if = {
-				limit = { 
-					SAF = { 
-						AND = { 
-							is_in_faction_with = ENG 
-							OR = { 
-								has_government = neutrality
-								has_government = democratic
-							}
-						}
-					}
-				}
-				add_opinion_modifier = { target = SAF modifier = bra_comercio_modifier }
-			}
-			if = {
-				limit = { 
-					AST = { 
-						AND = { 
-							is_in_faction_with = ENG 
-							OR = { 
-								has_government = neutrality
-								has_government = democratic
-							}
-						}
-					}
-				}
-				add_opinion_modifier = { target = AST modifier = bra_comercio_modifier }
-			}
-			if = {
-				limit = { 
-					NZL = { 
-						AND = { 
-							is_in_faction_with = ENG 
-							OR = { 
-								has_government = neutrality
-								has_government = democratic
-							}
-						}
-					}
-				}
-				add_opinion_modifier = { target = NZL modifier = bra_comercio_modifier }
-			}
-			if = {
-				limit = { 
-					CAN = { 
-						AND = { 
-							is_in_faction_with = ENG 
-							OR = { 
-								has_government = neutrality
-								has_government = democratic
-							}
-						}
-					}
-				}
-				add_opinion_modifier = { target = CAN modifier = bra_comercio_modifier }
-			}
-			if = {
-				limit = { 
-					MAL = { 
-						AND = { 
-							is_in_faction_with = ENG 
-							OR = { 
-								has_government = neutrality
-								has_government = democratic
-							}
-						}
-					}
-				}
-				add_opinion_modifier = { target = MAL modifier = bra_comercio_modifier }
+				add_opinion_modifier = { target = BRA modifier = bra_comercio_modifier }
 			}
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
 	}
-	
+
 	focus = {
 		id = bra_liga_nacoes
 		icon = GFX_goal_generic_major_alliance
@@ -2640,7 +2476,7 @@ focus = {
 		ai_will_do = {
 			factor = 1
 		}
-		available = { 
+		available = {
 			OR = {
 				has_government = democratic
 				has_government = neutrality
@@ -2652,8 +2488,8 @@ focus = {
 				is_faction_leader = yes
 				is_major = yes
 				has_government = democratic
-			}			
-		}		
+			}
+		}
 		completion_reward = {
 			if = {
 				limit = {
@@ -2668,7 +2504,7 @@ focus = {
 							is_in_faction_with = ENG
 							has_war_with = ROOT
 						}
-					}					
+					}
 				}
 				ENG = { country_event = { days = 1 id = bra.7 } }
 			}
@@ -2678,10 +2514,9 @@ focus = {
 					country_event = generic.2
 				}
 			}
-			
-		}		
+		}
 	}
-	
+
 	focus = {
 		id = bra_mercosul_militar_focus
 		icon = GFX_goal_generic_military_sphere
@@ -2693,30 +2528,31 @@ focus = {
 		ai_will_do = {
 			factor = 1
 		}
+		available = {
+			is_subject = no
+		}
 		completion_reward = {
 			set_global_flag = bra_doutrina_contestada
 			
 			custom_effect_tooltip = bra_inimigo_eua_tooltip
 			
 			custom_effect_tooltip = bra_mercosul_militar_tooltip
-			 
+			
 			set_rule = { can_create_factions = yes }
 			create_faction = "MERCOSUL"
 			
 			every_other_country = {
-				limit = { 
-					AND = {
-						capital_scope = { is_on_continent = south_america }
-						has_opinion_modifier = bra_amigo_modifier
-						has_opinion_modifier = bra_comercio_mercosul_modifier
-					}
+				limit = {
+					capital_scope = { is_on_continent = south_america }
+					has_opinion_modifier = bra_amigo_modifier
+					has_opinion_modifier = bra_comercio_mercosul_modifier
 				}
 				country_event = { days = 1 id = bra.6 }
 			}
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
 	}
-	
+
 	focus = {
 		id = bra_mercosul_expansao_focus
 		icon = GFX_goal_generic_occupy_states_ongoing_war
@@ -2729,19 +2565,14 @@ focus = {
 		}
 		cost = 5
 		completion_reward = {
-			USA = {
-				diplomatic_relation = { country = VEN relation = guarantee active = no }
-				}
-			USA = {
-				diplomatic_relation = { country = PRU relation = guarantee active = no }
-				}
-			if = { limit = { VEN = { has_government = fascism } } create_wargoal = { type = topple_government target = VEN 
-				expire = 0} }
-			if = { limit = { PRU = { has_government = fascism } } create_wargoal = { type = topple_government target = PRU 
-				expire = 0} }
+			every_other_country = {
+				limit = { capital_scope = { is_on_continent = south_america } has_government = fascism }
+				USA = { diplomatic_relation = { country = PREV relation = guarantee active = no } }
+				BRA = { create_wargoal = { type = topple_government target = PREV expire = 0 } }
+			}
 		}
 	}
-	
+
 	focus = {
 		id = bra_amigo_portugal
 		icon = GFX_goal_rhineland
@@ -2750,6 +2581,9 @@ focus = {
 		x = 0
 		y = 1
 		cost = 5
+		bypass = {
+			NOT = { country_exists = POR }
+		}
 		completion_reward = {
 			POR = { country_event = { days = 1 id = bra.8 } }
 		}
@@ -2857,31 +2691,31 @@ focus = {
 							is_in_faction_with = SOV
 							has_war_with = ROOT
 						}
-					}					
+					}
 				}
 				
 				SOV = { country_event = { days = 1 id = bra.7 } }
 				add_opinion_modifier = { target = SOV modifier = bra_comercio_modifier }
 				add_opinion_modifier = { target = SOV modifier = bra_amigo_modifier }
 				SOV = { add_opinion_modifier = { target = BRA modifier = bra_amigo_outro_modifier } }
-				
 			}
+
 			else = {
 				get_best_alliance_match_communism_effect = yes
 				var:best_leader = {
 					country_event = generic.2
 				}
-			}			
-
+			}
 		}
 	}
+
 	focus = {
 		id = bra_sem_urss
 		icon = GFX_focus_ger_break_anglo_french_colonial_hegemony
 		prerequisite = { focus = bra_inimigo_eua }
 		mutually_exclusive = { focus = bra_amigo_alemanha}
 		mutually_exclusive = { focus = bra_amigo_urss }
-		available = { has_government = communism }
+		available = { has_government = communism is_subject = no }
 		relative_position_id = bra_inimigo_eua
 		x = 1
 		y = 1
@@ -2897,26 +2731,24 @@ focus = {
 						has_government = communism
 						NOT = {
 							has_war_with = ROOT
-						}	
+						}
 					}
 				}
-				r56_other_faction_invite_communism_NOT_SOV = yes					
+				r56_other_faction_invite_communism_NOT_SOV = yes
 			}
 			else = {
 				set_rule = { can_create_factions = yes }
 				create_faction = "Internacional Americana"
 				if = {
-					limit = { 
-						PAR = { 
-							AND = { 
-								has_government = communism
-								NOT = { is_in_faction = yes }
-							}
+					limit = {
+						PAR = {
+							has_government = communism
+							NOT = { is_in_faction = yes }
 						}
-					}	
+					}
 					add_to_faction = PAR
-				}				
-			}			
+				}
+			}
 
 			add_opinion_modifier = { target = SOV modifier = bra_comercio_inimigo_modifier }
 			add_opinion_modifier = { target = SOV modifier = bra_inimigo_modifier }
@@ -2924,7 +2756,7 @@ focus = {
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
 	}
-	
+
 	focus = {
 		id = bra_pan_americano
 		icon = GFX_goal_CHL_liberate_south_america
@@ -2934,13 +2766,9 @@ focus = {
 		bypass = {
 			OR = {
 				AND = {
-				 	ARG = {
-					r56_script_standard_bypass = yes
-						}
-						URG = {
-					r56_script_standard_bypass = yes
-						}
-					}
+					ARG = { r56_script_standard_bypass = yes }
+					URG = { r56_script_standard_bypass = yes }
+				}
 				300 = { is_owned_by = BRA }
 				278 = { is_owned_by = BRA }
 				512 = { is_owned_by = BRA }
@@ -2953,10 +2781,8 @@ focus = {
 		y = 1
 		cost = 5
 		completion_reward = {
-			create_wargoal = { type = puppet_wargoal_focus target = ARG 
-				expire = 0}
-			create_wargoal = { type = puppet_wargoal_focus target = URG 
-				expire = 0}
+			create_wargoal = { type = puppet_wargoal_focus target = ARG expire = 0 }
+			create_wargoal = { type = puppet_wargoal_focus target = URG expire = 0 }
 		}
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 	}
@@ -2993,12 +2819,12 @@ focus = {
 		icon = GFX_goal_generic_war_with_comintern
 		prerequisite = { focus = bra_foro_de_sao_paulo_focus }
 		bypass = {
-		OR = {
-		CUB = { has_government = communism }
-		is_in_faction_with = CUB
+			OR = {
+				CUB = { has_government = communism }
+				is_in_faction_with = CUB
 			}
 		}
-		available = { 
+		available = {
 			has_government = communism
 			CUB = { communism > 0.45 }
 		}
@@ -3011,7 +2837,7 @@ focus = {
 			CUB = { start_civil_war = { ideology = communism size = 0.75 } }
 		}
 	}
-	
+
 	focus = {
 		id = bra_amigo_alemanha
 		icon = GFX_goal_support_fascism
@@ -3036,14 +2862,17 @@ focus = {
 		prerequisite = { focus = bra_amigo_alemanha }
 		mutually_exclusive = { focus = bra_sem_eixo }
 		relative_position_id = bra_amigo_alemanha
-		available = { 
-			OR = { has_government = fascism has_government = neutrality } 
-			GER = { 
+		available = {
+			is_subject = no
+			OR = { has_government = fascism has_government = neutrality }
+			GER = {
 				has_government = fascism
 				is_puppet = no
 				is_faction_leader = yes
 			}
 		}
+		bypass = { is_in_faction_with = GER }
+
 		x = 1
 		y = 1
 		cost = 5
@@ -3051,57 +2880,51 @@ focus = {
 			GER = { country_event = { days = 1 id = bra.7 } }
 		}
 	}
-	
+
 	focus = {
 		id = bra_sem_eixo
 		icon = GFX_goal_generic_more_territorial_claims
 		mutually_exclusive = { focus = bra_eixo }
 		prerequisite = { focus = bra_amigo_alemanha }
 		relative_position_id = bra_amigo_alemanha
-		available = { OR = { has_government = fascism has_government = neutrality } }
+		available = { OR = { has_government = fascism has_government = neutrality } is_subject = no }
 		x = -1
 		y = 1
 		cost = 5
 		completion_reward = {
-		set_rule = { can_create_factions = yes }
-		create_faction = "Rio Pact"
+			set_rule = { can_create_factions = yes }
+			create_faction = "Rio Pact"
 			if = {
-				limit = { 
-					PRU = { 
-						AND = { 
-							has_government = fascism
-							NOT = { is_in_faction = yes }
-						}
+				limit = {
+					PRU = {
+						has_government = fascism
+						NOT = { is_in_faction = yes }
 					}
-				}	
+				}
 				PRU = { country_event = { id = generic.5 hours = 24 } }
 			}
 			if = {
-				limit = { 
-					VEN = { 
-						AND = { 
-							has_government = fascism
-							NOT = { is_in_faction = yes }
-						}
+				limit = {
+					VEN = {
+						has_government = fascism
+						NOT = { is_in_faction = yes }
 					}
-				}	
+				}
 				VEN = { country_event = { id = generic.5 hours = 6 } }
 			}
 			if = {
-				limit = { 
-					COL = { 
-						AND = { 
-							has_government = fascism
-							NOT = { is_in_faction = yes }
-						}
+				limit = {
+					COL = {
+						has_government = fascism
+						NOT = { is_in_faction = yes }
 					}
-				}	
+				}
 				COL = { country_event = { id = generic.5 hours = 6 } }
-			}						
+			}
 			add_political_power = 75
 			custom_effect_tooltip = bra_uiracu_tooltip
 			#unlock_decision_category_tooltip = BRA_uiracu
-			#unlock_decision_tooltip = { decision = bra_inv_arg show_effect_tooltip = yes }		
+			#unlock_decision_tooltip = { decision = bra_inv_arg show_effect_tooltip = yes }
 		}
 		search_filters = { FOCUS_FILTER_POLITICAL }
 	}
@@ -3139,13 +2962,9 @@ focus = {
 		bypass = {
 			OR = {
 				AND = {
-				 	PAR = {
-					r56_script_standard_bypass = yes
-						}
-						COL = {
-					r56_script_standard_bypass = yes
-						}
-					}
+					PAR = { r56_script_standard_bypass = yes }
+					COL = { r56_script_standard_bypass = yes }
+				}
 				494 = { is_owned_by = BRA }
 				492 = { is_owned_by = BRA }
 				303 = { is_owned_by = BRA }
@@ -3157,26 +2976,25 @@ focus = {
 		}
 		cost = 5
 		completion_reward = {
-			create_wargoal = { type = take_state_focus target = PAR 
-				expire = 0}
-			create_wargoal = { type = take_state_focus target = COL 
-				expire = 0}
+			create_wargoal = { type = take_state_focus target = PAR expire = 0 }
+			create_wargoal = { type = take_state_focus target = COL expire = 0 }
 		}
 		search_filters = { FOCUS_FILTER_ANNEXATION }
 	}
+
 	focus = {
 		id = bra_mex_rev
 		icon = GFX_goal_support_fascism
 		prerequisite = { focus = bra_pan_americano_fascism }
 		relative_position_id = bra_pan_americano_fascism
-		available = { 
-		MEX = { fascism > 0.45 }
-		has_government = fascism 
+		available = {
+			MEX = { fascism > 0.45 }
+			has_government = fascism
 		}
 		bypass = {
-		OR = {
-		MEX = { has_government = fascism }
-		is_in_faction_with = MEX
+			OR = {
+				MEX = { has_government = fascism }
+				is_in_faction_with = MEX
 			}
 		}
 		x = 0
@@ -3190,20 +3008,20 @@ focus = {
 	focus = {
 		id = bra_basta
 		icon = GFX_focus_generic_strike_at_democracy3
-		prerequisite = { 
-		focus = bra_mex_rev
-		focus = bra_cuba_rev
+		prerequisite = {
+			focus = bra_mex_rev
+			focus = bra_cuba_rev
 		}
 		relative_position_id = bra_mex_rev
 		x = -2
 		y = 1
 		cost = 5
 		completion_reward = {
-			create_wargoal = { type = annex_everything target = USA 
-				expire = 0}
+			create_wargoal = { type = annex_everything target = USA expire = 0 }
 		}
 		search_filters = { FOCUS_FILTER_ANNEXATION }
-	}	
+	}
+
 	focus = {
 		id = bra_ciclocana
 		icon = GFX_goal_generic_production
@@ -3217,19 +3035,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 40
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 40
@@ -3252,19 +3065,14 @@ focus = {
 			
 			if = {
 				limit = {
-					AND = {
-						has_idea = bra_industrial_elite
-					}
+					has_idea = bra_industrial_elite
 				}
 				modify_timed_idea = {
 					idea = bra_industrial_elite
 					days = 40
 				}
 			}
-			else_if = {
-				limit = {
-					NOT = { has_idea = bra_industrial_elite }
-				}
+			else = {
 				add_timed_idea = {
 					idea = bra_industrial_elite
 					days = 40
@@ -3272,6 +3080,7 @@ focus = {
 			}
 		}
 	}
+
 	focus = {
 		id = bra_territoriosfederais
 		icon = GFX_goal_generic_position_armies

--- a/common/national_focus/brazil.txt
+++ b/common/national_focus/brazil.txt
@@ -2582,7 +2582,10 @@ focus = {
 		y = 1
 		cost = 5
 		bypass = {
-			NOT = { country_exists = POR }
+			OR = {
+				NOT = { country_exists = POR }
+				POR = { is_subject = yes }
+			}
 		}
 		completion_reward = {
 			POR = { country_event = { days = 1 id = bra.8 } }
@@ -2597,6 +2600,10 @@ focus = {
 		x = 0
 		y = 1
 		cost = 5
+		available = {
+			country_exists = ARG
+			ARG = { is_subject = no }
+		}
 		completion_reward = {
 			ARG = { country_event = { days = 1 id = bra.8 } }
 		}


### PR DESCRIPTION
Added some sanity checks so things like puppet Brazil creating a faction don't happen.
Added bypass to "Our former Overord" (bra_amigo_portugal) in case Portugal ceases to exist. The focus "Our greatest enemy" (bra_amigo_argentina ) now requires Argentina to both exist and not be a subject. Also, the entire branch is no longer available if neither Portugal or Argentina exists (for being pointless), if neither is independent (for being wonky) or some combination.
Expanded bra_mercosul_expansao_focus to grant cassus belli against any fascist nation on the continent rather than just Peru and Venezuela.
The IA won't chose "The Allied Cause" (bra_amigo_aliados) if UK becomes a subject OR stops being democratic, for being self-defeating. Also, the effect was streamlined.
Streamlined "Treaty of Commerce and Navigation" (bra_amigo_uk effect)
Optimized effect of the focus "Tiro de Guerra" (bra_tiro_de_guerra). It's also easier to read now.
Simplified the logic of the adding/extending of the idea "Construction contracting" (bra_industrial_elite): All "else_if" were replaced with "else", resulting in one less tick for the same effect.
Removed some redundancies. Also, some formatting.