### PR TITLE
Update r56_nicaragua.txt

### DIFF
--- a/events/r56_nicaragua.txt
+++ b/events/r56_nicaragua.txt
@@ -15,7 +15,9 @@
 			set_politics = { 
 				ruling_party = neutrality
 			}
-
+			hidden_effect = {
+				set_country_flag = NIC_somoza_in_power
+			}
 		}
 	}
 


### PR DESCRIPTION
Added a hidden effect on the Nicaraguan version of the Somoza takeover flag so the political advisors can be taken properly.