### PR TITLE
Changes to the Initial Lithuanian Army

### DIFF
--- a/history/units/LIT_1936.txt
+++ b/history/units/LIT_1936.txt
@@ -14,6 +14,23 @@
 		infantry = { x = 2 y = 2 }
 	}
 }
+division_template = {
+	name = "Šarvuočių Rinktinė"		
+
+	regiments = {
+		light_armor = { x = 0 y = 0 }
+		light_armor = { x = 0 y = 1 }
+	}
+}
+division_template = {
+	name = "Husarų Pulkas"
+	division_names_group = LIT_CAV_01
+	regiments = {
+		cavalry = { x = 0 y = 0 }
+		cavalry = { x = 0 y = 1 }
+		cavalry = { x = 0 y = 2 }
+	}
+}
 
 units = {
 	######## LAND OOB ########
@@ -27,7 +44,7 @@ units = {
 		division_template = "Pestininku Divizija"
 		force_equipment_variants = { infantry_equipment_0 = { owner = "LIT" } }
 		start_experience_factor = 0.1
-		start_equipment_factor = 0.2
+		start_equipment_factor = 0.4
 
 	}
 	division = { # "II. Divizija"
@@ -39,7 +56,7 @@ units = {
 		division_template = "Pestininku Divizija"
 		force_equipment_variants = { infantry_equipment_0 = { owner = "LIT" } }
 		start_experience_factor = 0.1
-		start_equipment_factor = 0.2
+		start_equipment_factor = 0.4
 
 	}
 	division = { # "III. Divizija"
@@ -50,6 +67,29 @@ units = {
 		location = 6296
 		division_template = "Pestininku Divizija"
 		force_equipment_variants = { infantry_equipment_0 = { owner = "LIT" } }
+		start_experience_factor = 0.1
+		start_equipment_factor = 0.4
+
+	}
+	division = { # "Šarvuočių Rinktinė"
+		division_name = {
+				is_name_ordered = yes
+				name_order = 1
+		}
+		location = 6229
+		division_template = "Šarvuočių Rinktinė"
+		force_equipment_variants = { gw_tank_equipment = { owner = "ENG" } }
+		start_experience_factor = 0.1
+		start_equipment_factor = 0.5
+
+	}
+	division = { # "Husarų Pulkas"
+		division_name = {
+				is_name_ordered = yes
+				name_order = 1
+		}
+		location = 6229
+		division_template = "Husarų Pulkas"
 		start_experience_factor = 0.1
 		start_equipment_factor = 0.2
 


### PR DESCRIPTION
Changes were made to better reflect reality

Sources:
Tanks - https://lt.wikipedia.org/wiki/%C5%A0arvuo%C4%8Di%C5%B3_rinktin%C4%97 (Translated From Lithuanian)
Cavalry - https://www.vle.lt/straipsnis/husaru-pulkas/ (Translated From Lithuanian)
Starting Equipment - https://lt.wikipedia.org/wiki/Tarpukario_Lietuvos_kariuomen%C4%97 (Translated From Lithuanian)