### PR TITLE
Communist YUG dipomatic restructure+minor SOV fixes

### DIFF
--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -4468,28 +4468,33 @@ focus = {
 			#add_state_claim = 191
 			#add_state_claim = 13
 			add_named_threat = { threat = 1 name = SOV_baltic_security }
-			FIN = {
-				add_timed_idea = {
-					idea = communist_pressure
-					days = 365
+			if = {
+				limit = {
+					has_government = communism
+					}
+				FIN = {
+					add_timed_idea = {
+						idea = communist_pressure
+						days = 365
+					}
 				}
-			}
-			SWE = {
-				add_timed_idea = {
-					idea = communist_pressure
-					days = 365
+				SWE = {
+					add_timed_idea = {
+						idea = communist_pressure
+						days = 365
+					}
 				}
-			}
-			DEN = {
-				add_timed_idea = {
-					idea = communist_pressure
-					days = 365
+				DEN = {
+					add_timed_idea = {
+						idea = communist_pressure
+						days = 365
+					}
 				}
-			}
-			NOR = {
-				add_timed_idea = {
-					idea = communist_pressure
-					days = 365
+				NOR = {
+					add_timed_idea = {
+						idea = communist_pressure
+						days = 365
+					}
 				}
 			}
 			hidden_effect = {

--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -6799,31 +6799,14 @@ focus = {
 		icon = GFX_goal_generic_forceful_treaty
 		prerequisite = { focus = SOV_stalin_constitution }
 		available = {
-			OR = {
-				has_war_with = GER
-				has_war_with = JAP
-				has_war_with = ENG
-				has_war_with = FRA
-				has_war_with = USA
-				has_war_with = ITA
-				any_other_country = {
+				any_country = {
 					OR = {
-						has_cosmetic_tag = SCA_UNIFIED
-						has_cosmetic_tag = NDC_UNIFIED
-						has_cosmetic_tag = HUN_EMPIRE
-						custom_trigger_tooltip = {
-							tooltip = has_cosmetic_tag_smersh_tt	
+						is_major = yes
+						num_of_factories > 60
 						}
-						AND = {
-							is_major = yes
-							num_of_factories > 100
-						}
-						
-					}
 					has_war_with = ROOT
-				}
-			}
-		}
+					}
+			    }
 		bypass = {
 		#	NOT = { has_idea = trotskyite_plot_purged }
 		}

--- a/common/national_focus/yugoslavia.txt
+++ b/common/national_focus/yugoslavia.txt
@@ -3331,6 +3331,10 @@ focus_tree = {
 		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
+			add_popularity = {
+    				ideology = communism
+    				popularity = 0.05
+			}
 			add_timed_idea = { idea = YUG_idea_economic_aid days = 720 }
 			SOV = {
 				add_timed_idea = { idea = YUG_idea_economic_aid days = 365 }
@@ -3559,7 +3563,7 @@ focus_tree = {
 	focus = {
 		id = YUG_form_the_federal_republic
 		icon = GFX_goal_yug_tito
-		prerequisite = { focus = YUG_yugoslavian_path_to_communism focus = YUG_join_comintern focus = YUG_yugoslavian_international_communism  }
+		prerequisite = { focus = YUG_yugoslavian_path_to_communism focus = YUG_soviet_cooperation focus = YUG_yugoslavian_international_communism  }
 		x = -3
 		y = 1
 		relative_position_id = YUG_yugoslavian_path_to_communism

--- a/common/national_focus/yugoslavia.txt
+++ b/common/national_focus/yugoslavia.txt
@@ -3485,7 +3485,7 @@ focus_tree = {
 		}
 
 		bypass = {
-			is_in_faction = yes
+		#	is_in_faction = yes
 		}
 
 		cancel_if_invalid = yes

--- a/common/national_focus/yugoslavia.txt
+++ b/common/national_focus/yugoslavia.txt
@@ -3310,7 +3310,7 @@ focus_tree = {
 		cost = 10
 
 		ai_will_do = {
-			factor = 200
+			factor = 40
 		}
 
 		available = {
@@ -3328,7 +3328,7 @@ focus_tree = {
 		cancel_if_invalid = yes
 		continue_if_invalid = no
 		available_if_capitulated = no
-		search_filters = { FOCUS_FILTER_INDUSTRY }
+		search_filters = { FOCUS_FILTER_INDUSTRY FOCUS_FILTER_POLITICAL }
 
 		completion_reward = {
 			add_timed_idea = { idea = YUG_idea_economic_aid days = 720 }
@@ -3400,12 +3400,12 @@ focus_tree = {
 		prerequisite = { focus = YUG_soviet_cooperation }
 		x = -1
 		y = 1
-		relative_position_id = YUG_abolish_the_monarchy
+		relative_position_id = YUG_soviet_cooperation
 
 		cost = 10
 
 		ai_will_do = {
-			factor = 40
+			factor = 80
 		}
 
 		available = {
@@ -3506,7 +3506,7 @@ focus_tree = {
 		cost = 5
 
 		ai_will_do = {
-			factor = 20
+			factor = 70
 		}
 
 		available = {
@@ -3650,7 +3650,7 @@ focus_tree = {
 			remove_ideas = YUG_idea_slovene_nationalism
 			add_stability = 0.03
 		}
-		search_filters = {  }
+		search_filters = { FOCUS_FILTER_STABILITY }
 	}
 	focus = {
 		id = YUG_pan_slavic_workers_congress
@@ -4724,6 +4724,7 @@ focus_tree = {
 					OR = {
 						has_completed_focus = YUG_join_comintern
 						has_completed_focus = YUG_yugoslavian_path_to_communism
+						has_completed_focus = YUG_yugoslavian_international_communism
 					}
 				}
 		}
@@ -4764,6 +4765,7 @@ focus_tree = {
 					OR = {
 						has_completed_focus = YUG_join_comintern
 						has_completed_focus = YUG_yugoslavian_path_to_communism
+						has_completed_focus = YUG_yugoslavian_international_communism
 					}
 			}
 		}
@@ -4875,6 +4877,7 @@ focus_tree = {
 					OR = {
 						has_completed_focus = YUG_join_comintern
 						has_completed_focus = YUG_yugoslavian_path_to_communism
+						has_completed_focus = YUG_yugoslavian_international_communism
 					}
 			}
 		}
@@ -4940,6 +4943,7 @@ focus_tree = {
 					OR = {
 						has_completed_focus = YUG_join_comintern
 						has_completed_focus = YUG_yugoslavian_path_to_communism
+						has_completed_focus = YUG_yugoslavian_international_communism
 					}
 				}
 		}
@@ -5062,6 +5066,7 @@ focus_tree = {
 					OR = {
 						has_completed_focus = YUG_join_comintern
 						has_completed_focus = YUG_yugoslavian_path_to_communism
+						has_completed_focus = YUG_yugoslavian_international_communism
 					}
 				}
 		}
@@ -5140,6 +5145,7 @@ focus_tree = {
 					OR = {
 						has_completed_focus = YUG_join_comintern
 						has_completed_focus = YUG_yugoslavian_path_to_communism
+						has_completed_focus = YUG_yugoslavian_international_communism
 					}
 				}
 		}
@@ -5295,6 +5301,7 @@ focus_tree = {
 					OR = {
 						has_completed_focus = YUG_join_comintern
 						has_completed_focus = YUG_yugoslavian_path_to_communism
+						has_completed_focus = YUG_yugoslavian_international_communism
 					}
 				}
 		}

--- a/common/national_focus/yugoslavia.txt
+++ b/common/national_focus/yugoslavia.txt
@@ -3270,7 +3270,7 @@ focus_tree = {
 		id = YUG_form_peasant_councils
 		icon = GFX_goal_communist_revolt
 		prerequisite = { focus = YUG_recognize_the_soviet_union }
-		x = -1
+		x = 0
 		y = 1
 		relative_position_id = YUG_recognize_the_soviet_union
 
@@ -3299,12 +3299,13 @@ focus_tree = {
 	}
 
 	focus = {
-		id = YUG_mutual_economic_aid
-		icon = GFX_goal_generic_soviet_construction
-		prerequisite = { focus = YUG_recognize_the_soviet_union }
-		x = 1
+		id = YUG_soviet_cooperation
+		icon = GFX_focus_chi_mission_to_the_soviet_union
+		prerequisite = { focus = YUG_abolish_the_monarchy }
+		mutually_exclusive = { focus = YUG_yugoslavian_path_to_communism focus = YUG_yugoslavian_international_communism }
+		x = -1
 		y = 1
-		relative_position_id = YUG_recognize_the_soviet_union
+		relative_position_id = YUG_abolish_the_monarchy
 
 		cost = 10
 
@@ -3351,7 +3352,6 @@ focus_tree = {
 		id = YUG_abolish_the_monarchy
 		icon = GFX_goal_tfv_burn_the_royal_portraits
 		prerequisite = { focus = YUG_form_peasant_councils }
-		prerequisite = { focus = YUG_mutual_economic_aid }
 		x = 0
 		y = 2
 		relative_position_id = YUG_recognize_the_soviet_union
@@ -3397,8 +3397,7 @@ focus_tree = {
 	focus = {
 		id = YUG_join_comintern
 		icon = GFX_focus_generic_join_comintern
-		prerequisite = { focus = YUG_abolish_the_monarchy }
-		mutually_exclusive = { focus = YUG_yugoslavian_path_to_communism }
+		prerequisite = { focus = YUG_soviet_cooperation }
 		x = -1
 		y = 1
 		relative_position_id = YUG_abolish_the_monarchy
@@ -3466,10 +3465,10 @@ focus_tree = {
 		id = YUG_yugoslavian_path_to_communism
 		icon = GFX_goal_generic_war_with_comintern
 		prerequisite = { focus = YUG_abolish_the_monarchy }
-		mutually_exclusive = { focus = YUG_join_comintern }
-		x = 1
+		mutually_exclusive = { focus = YUG_soviet_cooperation focus = YUG_yugoslavian_international_communism }
+		x = -1
 		y = 1
-		relative_position_id = YUG_abolish_the_monarchy
+		relative_position_id = YUG_soviet_cooperation
 
 		cost = 5
 
@@ -3494,12 +3493,74 @@ focus_tree = {
 			swap_ideas = { remove_idea = YUG_idea_empowered_peasant_councils add_idea = YUG_idea_very_empowered_peasant_councils }
 		}
 	}
+	
+	focus = {
+		id = YUG_yugoslavian_international_communism
+		icon = GFX_focus_generic_diplomatic_treaty
+		prerequisite = { focus = YUG_abolish_the_monarchy }
+		mutually_exclusive = { focus = YUG_join_comintern focus = YUG_yugoslavian_path_to_communism }
+		x = 2
+		y = 1
+		relative_position_id = YUG_abolish_the_monarchy
+
+		cost = 5
+
+		ai_will_do = {
+			factor = 20
+		}
+
+		available = {
+			is_in_faction = no
+			any_other_country = {
+					capital_scope = {
+						is_on_continent = europe
+					}
+					NOT = {
+						original_tag = SOV
+					}
+					is_faction_leader = yes
+					has_government = communism
+					NOT = {
+						has_war_with = ROOT
+					}
+			}
+		}
+
+		bypass = {
+			is_in_faction = yes
+		}
+
+		cancel_if_invalid = yes
+		continue_if_invalid = no
+		available_if_capitulated = no
+		completion_reward = {
+		if = {
+				limit = {
+					any_other_country = {
+						capital_scope = {
+							is_on_continent = europe
+						}
+						NOT = {
+							original_tag = SOV
+						}
+						is_faction_leader = yes
+						has_government = communism
+						NOT = {
+							has_war_with = ROOT
+						}
+					}
+				}
+				r56_other_faction_invite_communism_NOT_SOV = yes
+			}
+		}
+		search_filters = { FOCUS_FILTER_POLITICAL }
+	}	
 
 	focus = {
 		id = YUG_form_the_federal_republic
 		icon = GFX_goal_yug_tito
-		prerequisite = { focus = YUG_yugoslavian_path_to_communism focus = YUG_join_comintern }
-		x = 1
+		prerequisite = { focus = YUG_yugoslavian_path_to_communism focus = YUG_join_comintern focus = YUG_yugoslavian_international_communism  }
+		x = -3
 		y = 1
 		relative_position_id = YUG_yugoslavian_path_to_communism
 
@@ -3595,7 +3656,7 @@ focus_tree = {
 		id = YUG_pan_slavic_workers_congress
 		icon = GFX_focus_YUG_pan_slavic_congress
 		prerequisite = { focus = YUG_yugoslavian_path_to_communism }
-		x = 6
+		x = 2
 		y = 1
 		relative_position_id = YUG_yugoslavian_path_to_communism
 
@@ -3620,26 +3681,8 @@ focus_tree = {
 
 		completion_reward = {
 			add_political_power = 50
-			if = {
-				limit = {
-					any_other_country = {
-						NOT = {
-							original_tag = SOV
-							original_tag = BRA #the player has no choice and this faction makes little sense for YUG
-						}
-						is_faction_leader = yes
-						has_government = communism
-						NOT = {
-							has_war_with = ROOT
-						}
-					}
-				}
-				r56_other_faction_invite_communism_NOT_SOV = yes
-			}
-			else = {
-				create_faction = panslavic_workers_congress
-				hidden_effect = { news_event = { id = news.330 } }
-			}
+			create_faction = panslavic_workers_congress
+			hidden_effect = { news_event = { id = news.330 } }
 			set_rule = { can_create_factions = yes }
 			
 			unlock_decision_tooltip = YUG_instigate_in_bulgaria

--- a/common/national_focus/yugoslavia.txt
+++ b/common/national_focus/yugoslavia.txt
@@ -3466,9 +3466,9 @@ focus_tree = {
 		icon = GFX_goal_generic_war_with_comintern
 		prerequisite = { focus = YUG_abolish_the_monarchy }
 		mutually_exclusive = { focus = YUG_soviet_cooperation focus = YUG_yugoslavian_international_communism }
-		x = -1
+		x = 5
 		y = 1
-		relative_position_id = YUG_soviet_cooperation
+		relative_position_id = YUG_abolish_the_monarchy
 
 		cost = 5
 

--- a/localisation/YUG_l_english.yml
+++ b/localisation/YUG_l_english.yml
@@ -5,6 +5,10 @@
  YUG_neutralize_the_opposition_desc:0 "Even if the new regime seems secure, fascist nationalists are still hiding within our borders or in exile. A new security service, shadowy arms of the party will be able to suppress those adversaries of the union of the southern Slavs."
  YUG_economic_centralization:0 "Economic Centralization"
  YUG_economic_centralization_desc:0 "to truly put the proletariat in power, the economy must be completely restructured. Corporations must be nationalized and renamed to honour the heroes of the yugoslav workers."
+ YUG_soviet_cooperation:0 "Soviet Cooperation"
+ YUG_soviet_cooperation_desc:0 "We must further cooperate with the Soviet Union to further develop our country and spread the cause of communism."
+ YUG_yugoslavian_international_communism:0 "European Communist Pact"
+ YUG_yugoslavian_international_communism_desc:0 "We can not rely on the Soviets for support and must look for other powerful allies to support our cause."
  YUG_invite_greece:0 "Invite Greece"
  YUG_invite_greece_desc:0 "While Greece is not a slavic country in any way, it's an important partner in the region and we must not push them in the arms of the Soviets."
  # Companies


### PR DESCRIPTION
Creates a bigger split between going with the Soviets vs own faction and splits off the joining of a different communist faction in a new separate focus that filters for European nations
This also moves Soviet economic support down and changes it slightly, so it is less appealing to get the Yugoslavian communism focus but then still join the Soviets anyway
![image](https://user-images.githubusercontent.com/49281278/119270009-d84bda80-bbfa-11eb-9575-146a1126db75.png)
(image is without having the string file loaded)

Also includes an unrelated simplification (also removing a bug) of the soviet smersh focus availability check and stops a non-communist SOV (most often as puppet) from boosting communism with Baltic Security