### PR TITLE
Some tiny fixes + First Dutch changes

### DIFF
--- a/common/decisions/HOL.txt
+++ b/common/decisions/HOL.txt
@@ -1023,6 +1023,31 @@ HOL_gateway_to_europe_eng_category = {
 				has_global_flag = hol_mtg_focus_tree
 			}
 			has_civil_war = no
+			custom_trigger_tooltip = {
+				tooltip = HOL_can_ENG_or_GER_influence_tt
+				NOT = { #this is a bit confusing but we don't want them to be transitioning
+					OR = {
+						AND = { #transitioning to fascism
+							OR = {
+								has_completed_focus = ENG_organize_the_blackshirts
+								has_completed_focus = ENG_visit_germany
+							}
+							NOT = { has_government = fascism }
+						}
+						AND = { #transitioning to communism
+							OR = {
+								has_completed_focus = ENG_opposition_to_the_national_government
+								has_completed_focus = ENG_concessions_to_the_trade_unions
+							}
+							NOT = { has_government = communism }
+						}
+						AND = { #transitioning to monarchism
+							has_completed_focus = ENG_the_kings_party
+							NOT = { has_government = neutrality }
+						}
+					}
+				}
+			}
 		}
 
 		targets = { HOL }
@@ -1228,6 +1253,35 @@ HOL_gateway_to_europe_ger_category = {
 				has_global_flag = hol_mtg_focus_tree
 			}
 			has_civil_war = no
+			custom_trigger_tooltip = {
+				tooltip = HOL_can_ENG_or_GER_influence_tt
+				NOT = { #we want this to not be the case
+					OR = {
+						AND = { #DLC tree only needs focus checks
+							has_completed_focus = GER_oppose_hitler
+							NOT = { #has not stabilized
+								OR = {
+									has_completed_focus = GER_return_of_the_kaiser #has stabilized with Kaiser
+									has_completed_focus = GER_the_monarchy_compromise #has stabilized as democracy
+								}
+							}
+						}
+						AND = { #has not stabilized as non-DLC kaiserreich
+							has_completed_focus = GER_rally_the_monarchists
+							NOT = { has_completed_focus = GER_consolidate_new_reich }
+						}
+						AND = {
+							has_completed_focus = GER_kill_hitler
+							NOT = {
+								OR = { #by lack of better checks
+									has_government = communism
+									has_government = democratic
+								}
+							}
+						}
+					}
+				}
+			}
 		}
 
 		targets = { HOL }
@@ -1424,6 +1478,31 @@ HOL_gateway_to_europe_hol_category = {
 			ENG = {
 				exists = yes
 				has_civil_war = no
+				custom_trigger_tooltip = {
+					tooltip = HOL_is_placated_changing_gov_tt
+					NOT = { #this is a bit confusing but we don't want them to be transitioning
+						OR = {
+							AND = { #transitioning to fascism
+								OR = {
+									has_completed_focus = ENG_organize_the_blackshirts
+									has_completed_focus = ENG_visit_germany
+								}
+								NOT = { has_government = fascism }
+							}
+							AND = { #transitioning to communism
+								OR = {
+									has_completed_focus = ENG_opposition_to_the_national_government
+									has_completed_focus = ENG_concessions_to_the_trade_unions
+								}
+								NOT = { has_government = communism }
+							}
+							AND = { #transitioning to monarchism
+								has_completed_focus = ENG_the_kings_party
+								NOT = { has_government = neutrality }
+							}
+						}
+					}
+				}
 			}
 		}
 
@@ -1563,6 +1642,35 @@ HOL_gateway_to_europe_hol_category = {
 				exists = yes
 				#NOT = { has_completed_focus = GER_oppose_hitler }
 				has_civil_war = no
+				custom_trigger_tooltip = {
+					tooltip = HOL_is_placated_changing_gov_tt
+					NOT = { #we want this to not be the case
+						OR = {
+							AND = { #DLC tree only needs focus checks
+								has_completed_focus = GER_oppose_hitler
+								NOT = { #has not stabilized
+									OR = {
+										has_completed_focus = GER_return_of_the_kaiser #has stabilized with Kaiser
+										has_completed_focus = GER_the_monarchy_compromise #has stabilized as democracy
+									}
+								}
+							}
+							AND = { #has not stabilized as non-DLC kaiserreich
+								has_completed_focus = GER_rally_the_monarchists
+								NOT = { has_completed_focus = GER_consolidate_new_reich }
+							}
+							AND = {
+								has_completed_focus = GER_kill_hitler
+								NOT = {
+									OR = { #by lack of better checks
+										has_government = communism
+										has_government = democratic
+									}
+								}
+							}
+						}
+					}
+				}
 			}
 		}
 

--- a/common/decisions/HOL.txt
+++ b/common/decisions/HOL.txt
@@ -1015,14 +1015,14 @@ HOL_gateway_to_europe_eng_category = {
 
 		allowed = {
 			tag = ENG
+			has_civil_war = no
 		}
 
 		available = {
 			hidden_trigger = {
 				has_global_flag = hol_mtg_focus_tree
 			}
-			has_government = democratic
-			GER = { has_government = fascism }
+			has_civil_war = no
 		}
 
 		targets = { HOL }
@@ -1227,8 +1227,7 @@ HOL_gateway_to_europe_ger_category = {
 			hidden_trigger = {
 				has_global_flag = hol_mtg_focus_tree
 			}
-			has_government = fascism
-			ENG = { has_government = democratic }
+			has_civil_war = no
 		}
 
 		targets = { HOL }
@@ -1424,7 +1423,7 @@ HOL_gateway_to_europe_hol_category = {
 			HOL = { has_completed_focus = HOL_gateway_to_europe }
 			ENG = {
 				exists = yes
-				has_government = democratic
+				has_civil_war = no
 			}
 		}
 
@@ -1562,15 +1561,8 @@ HOL_gateway_to_europe_hol_category = {
 			HOL = { has_completed_focus = HOL_gateway_to_europe }
 			GER = {
 				exists = yes
-				has_government = fascism
 				#NOT = { has_completed_focus = GER_oppose_hitler }
-				NOT = {
-					OR ={
-						has_completed_focus = GER_oppose_hitler
-						has_completed_focus = GER_kill_hitler
-						has_completed_focus = GER_rally_the_monarchists
-					}
-				}				
+				has_civil_war = no
 			}
 		}
 

--- a/common/national_focus/netherlands_MtG.txt
+++ b/common/national_focus/netherlands_MtG.txt
@@ -3683,7 +3683,38 @@ focus_tree = {
 
 	focus = {
 		id = HOL_volk_en_vaderland
-		prerequisite = { focus = HOL_cave_to_the_germans }
+		available = {
+			custom_trigger_tooltip = {
+				tooltip = HOL_fascist_tt
+				OR = {
+					AND = {
+						has_completed_focus = HOL_maintain_trade_neutrality
+						GER = { NOT = { has_government = fascism } }
+						GER = { has_civil_war = no }
+						ENG = { NOT = { has_completed_focus = ENG_visit_germany } } #no DLC req, no civil war
+						ENG = { NOT = { has_completed_focus = ENG_organize_the_blackshirts } } #DLC req, no civil war
+					}
+					AND = {
+						has_completed_focus = HOL_cave_to_the_british
+						OR = {
+							ENG = { has_completed_focus = ENG_visit_germany } #no DLC req, no civil war
+							ENG = { has_completed_focus = ENG_organize_the_blackshirts } #DLC req, no civil war
+						}
+					}
+					AND = {
+						has_completed_focus = HOL_cave_to_the_germans
+						NOT = {
+							GER = { has_civil_war = yes }
+							GER = { has_completed_focus = GER_kill_hitler }
+							GER = { has_completed_focus = GER_oppose_hitler }
+							GER = { has_completed_focus = GER_rally_the_monarchists }
+						}
+					}
+				}
+			}
+		}
+		# prerequisite = { focus = HOL_cave_to_the_germans }
+		mutually_exclusive = { focus = HOL_oranje_boven focus = HOL_unity_through_democracy focus = HOL_legacy_of_the_de_zeven_provincien_mutiny }
 		icon = GFX_goal_HOL_NSB
 		x = -3
 		y = 1
@@ -4440,8 +4471,34 @@ focus_tree = {
 
  	focus = {
 		id = HOL_legacy_of_the_de_zeven_provincien_mutiny
-		prerequisite = { focus = HOL_maintain_trade_neutrality }
-		mutually_exclusive = { focus = HOL_oranje_boven }
+		available = {
+			custom_trigger_tooltip = {
+				tooltip = HOL_communist_tt
+				OR = {
+					AND = {
+						has_completed_focus = HOL_maintain_trade_neutrality
+						NOT = {
+							ENG = { has_completed_focus = ENG_concessions_to_the_trade_unions }
+							ENG = { has_completed_focus = ENG_opposition_to_the_national_government }
+							GER = { has_completed_focus = GER_repeal_reichstag_fire_decree } #r56 tree, no civil war
+						}
+					}
+					AND = {
+						has_completed_focus = HOL_cave_to_the_british
+						OR = {
+							ENG = { has_completed_focus = ENG_concessions_to_the_trade_unions }
+							ENG = { has_completed_focus = ENG_opposition_to_the_national_government }
+						}
+					}
+					AND = {
+						has_completed_focus = HOL_cave_to_the_germans
+						GER = { has_completed_focus = GER_repeal_reichstag_fire_decree } #r56 tree, no civil war
+					}
+				}
+			}
+		}
+		# prerequisite = { focus = HOL_maintain_trade_neutrality }
+		mutually_exclusive = { focus = HOL_oranje_boven focus = HOL_unity_through_democracy focus = HOL_volk_en_vaderland }
 		icon = GFX_focus_hol_legacy_of_the_de_zeven_provincien_mutiny
 		x = -2
 		y = 1
@@ -5329,9 +5386,31 @@ focus_tree = {
 		id = HOL_oranje_boven
 		available = {
 			NOT = { has_completed_focus = HOL_curtail_colonial_autonomy }
+			custom_trigger_tooltip = {
+				tooltip = HOL_monarchist_tt
+				OR = {
+					AND = {
+						has_completed_focus = HOL_maintain_trade_neutrality
+						NOT = { ENG = { has_completed_focus = ENG_the_kings_party } }
+						NOT = { GER = { has_completed_focus = GER_revive_the_kaiserreich } }
+						NOT = { GER = { has_completed_focus = GER_consolidate_new_reich } } #civil war check should be unnecessary due to the loser not being able to complete these anyway; victory required
+					}
+					AND = {
+						has_completed_focus = HOL_cave_to_the_british
+						ENG = { has_completed_focus = ENG_the_kings_party } #requires DLC, no civil war risk
+					}
+					AND = {
+						has_completed_focus = HOL_cave_to_the_germans
+						OR = {
+							GER = { has_completed_focus = GER_revive_the_kaiserreich } #DLC tree, civil war has to be over
+							GER = { has_completed_focus = GER_consolidate_new_reich } #r56 tree, civil war has to be over
+						}
+					}
+				}
+			}
 		}
-		prerequisite = { focus = HOL_maintain_trade_neutrality }
-		mutually_exclusive = { focus = HOL_legacy_of_the_de_zeven_provincien_mutiny }
+		# prerequisite = { focus = HOL_maintain_trade_neutrality }
+		mutually_exclusive = { focus = HOL_volk_en_vaderland focus = HOL_unity_through_democracy focus = HOL_legacy_of_the_de_zeven_provincien_mutiny }
 		icon = GFX_focus_hol_oranje_boven
 		x = 2
 		y = 1
@@ -5913,7 +5992,27 @@ focus_tree = {
 
 	focus = {
 		id = HOL_unity_through_democracy
-		prerequisite = { focus = HOL_cave_to_the_british }
+		available = {
+			custom_trigger_tooltip = {
+				tooltip = HOL_democratic_tt
+				OR = {
+					has_completed_focus = HOL_maintain_trade_neutrality
+					AND = {
+						has_completed_focus = HOL_cave_to_the_british
+						ENG = { has_completed_focus = ENG_steady_as_she_goes }
+					}
+					AND = {
+						has_completed_focus = HOL_cave_to_the_germans
+						OR = {
+							GER = { has_completed_focus = GER_reestablish_free_elections } #DLC tree, civil war has to be over
+							GER = { has_completed_focus = GER_establish_bundesrepublik } #r56 tree, no civil war
+						}
+					}
+				}
+			}
+		}
+		# prerequisite = { focus = HOL_cave_to_the_british }
+		mutually_exclusive = { focus = HOL_oranje_boven focus = HOL_volk_en_vaderland focus = HOL_legacy_of_the_de_zeven_provincien_mutiny }
 		icon = GFX_goal_support_democracy
 		x = 3
 		y = 1

--- a/common/national_focus/netherlands_MtG.txt
+++ b/common/national_focus/netherlands_MtG.txt
@@ -752,6 +752,15 @@ focus_tree = {
 		cost = 10
 
 		available_if_capitulated = yes
+		
+		ai_will_do = {
+			factor = 1
+			
+			modifier = {
+				has_completed_focus = HOL_cave_to_the_germans
+				factor = 0
+			}
+		}
 
 		completion_reward = {
 			add_timed_idea = {

--- a/common/national_focus/poland.txt
+++ b/common/national_focus/poland.txt
@@ -6550,11 +6550,14 @@ focus_tree = {
 				date > 1941.01.01
 			}
 			OR = {
-				85 = { is_owned_by = GER }
+				POL = { has_government = communism }
+				AND  = {
+					85 = { is_owned_by = GER }
+					NOT = { GER = { has_completed_focus = GER_danzig_for_guarantees } }
+				}
 				POL = { has_defensive_war = yes }
 				GER = { is_justifying_wargoal_against = POL }
 				GER = { has_wargoal_against = POL }
-				POL = { has_government = communism }
 			}
 			SOV = {
 				exists = yes

--- a/events/WTT_Germany.txt
+++ b/events/WTT_Germany.txt
@@ -2438,7 +2438,8 @@ country_event = {
 			OR = {
 				is_puppet = yes
 				country_exists = BAY
-				date > 1943.01.01
+				GER = { has_completed_focus = GER_anschluss_vanilla }
+				GER = { has_completed_focus = GER_anschluss }
 			}
 			
 		}

--- a/interface/countryconstructionsview.gui
+++ b/interface/countryconstructionsview.gui
@@ -316,7 +316,7 @@ guiTypes = {
 		
 		buttonType = {
 			name = "expand"
-			position = { x = -74 y = 603 }
+			position = { x = -74 y = 703 }
 			quadTextureSprite ="GFX_production_line_arrow_right"
 			buttonFont = "Main_14_black"
 			Orientation = "UPPER_RIGHT"

--- a/localisation/CUB_l_english.yml
+++ b/localisation/CUB_l_english.yml
@@ -55,7 +55,7 @@
  CUB_nationalist_influence_over_the_military:0 "Nationalist Influence Over the Military"
  CUB_secure_power:0 "Secure Power"
  CUB_spanish_civil_war_involvement:0 "Spanish Civil War Involvement"
- CUB_intervene_ACW:0 "Interven in the American Civil War"
+ CUB_intervene_ACW:0 "Intervene in the American Civil War"
  CUB_state_intervention:0 "State Intervention"
  CUB_invade_hispaniola:0 "Invade Hispaniola"
  CUB_amphibious_equipment:0 "Amphibious Equipment"

--- a/localisation/FRA_l_english.yml
+++ b/localisation/FRA_l_english.yml
@@ -983,7 +983,7 @@
  france.131.t:0 "Commit a Tank Designer"
  france.131.d:0 "To fullfil the demand in equipment of our army, we can hire a Tank Designer. What should we choose?"
  france.131.a:0 "Lorraine-Dietrich"
- france.131.b:0 "Berlier"
+ france.131.b:0 "Berliet"
  france.131.c:0 "Delaunay-Belleville"
  france.131.e:0 "Save the option for later"
  france.133.t:0 "French Ultimatum"

--- a/localisation/HOL_l_english.yml
+++ b/localisation/HOL_l_english.yml
@@ -607,3 +607,9 @@
  
  #form the benelux mtg focus (rewritten to make sense if VLA/WLL exists)
  HOL_propose_benelux_unification_tt:0 "§REveryone must approve of the agreement for the bonuses to take effect.§!"
+
+ #DLC trade/politics seperation tooltips
+ HOL_democratic_tt:0 "We must have either caved to democratic influence or have stayed neutral in our trade policy."
+ HOL_monarchist_tt:0 "We must have either caved to monarchist influence or we shall be pursuing a different government type from our influencers in order to keep up our neutral policy."
+ HOL_fascist_tt:0 "We must have either caved to fascist influence or we shall be pursuing a different government type from our influencers in order to keep up our neutral policy."
+ HOL_communist_tt:0 "We must have either caved to communist influence or we shall be pursuing a different government type from our influencers in order to keep up our neutral policy."

--- a/localisation/HOL_l_english.yml
+++ b/localisation/HOL_l_english.yml
@@ -613,3 +613,5 @@
  HOL_monarchist_tt:0 "We must have either caved to monarchist influence or we shall be pursuing a different government type from our influencers in order to keep up our neutral policy."
  HOL_fascist_tt:0 "We must have either caved to fascist influence or we shall be pursuing a different government type from our influencers in order to keep up our neutral policy."
  HOL_communist_tt:0 "We must have either caved to communist influence or we shall be pursuing a different government type from our influencers in order to keep up our neutral policy."
+ HOL_can_ENG_or_GER_influence_tt:0 "We are not currently in the process of transitioning to a different government type."
+ HOL_is_placated_changing_gov_tt:0 "Is not currently undergoing a regime change."

--- a/localisation/RAJ_l_english.yml
+++ b/localisation/RAJ_l_english.yml
@@ -643,19 +643,19 @@
  india.440.d:0 "Baseless rumours."
 
  india.441.t:0 "Famine in India"
- india.441.desc:0 "Due to the failing monsoons India, specifically Bengal is headed towards famine and the administration have cried out for our help and supplies. If we are to answer this call to action the Indian government and population will most certainly look favourably towards our nation. Aside from that, of course delivering food supplies is the moral choice and some might say our moral obligation. But if the ressources are available is not up to morality to decide."
+ india.441.desc:0 "Due to the failing monsoons India, specifically Bengal is headed towards famine and the administration have cried out for our help and supplies. If we are to answer this call to action the Indian government and population will most certainly look favourably towards our nation. Aside from that, of course delivering food supplies is the moral choice and some might say our moral obligation. But if the resources are available is not up to morality to decide."
  india.441.sov.desc:0 "Due to reckless British colonial administration India is headed towards famine and many of their native politicans have cried out for help from our prosperous Union. Some experts agree that millions of lives may be on the line if India doesn't receive external supplies to keep its poverty-ridden population fed. Aside from the questioning morality of denying this request it may also help wake up the Indian people to the neglect and oppression they have been facing for three centuries. General Secretary, the choice is yours."
  india.441.a:0 "We'll supply our comrades in India!"
  india.441.b:0 "Send the goods, send a little democracy with it."
  india.441.c:0 "Anything for the Jewel."
- india.441.d:0 "We lack the ressources."
+ india.441.d:0 "We lack the resources."
 
  india.442.t:0 "The [From.GetAdjective] Response"
  india.442.desc:0 "It seems that [From.GetLeader] has thought hard about his response and luckily for the millions of lives at stake he has come out in favour of food shipments at the cost of his own economy."
  india.442.a:0 "Bengal breathes a sigh of relief"
  
  india.443.t:0 "The [From.GetAdjective] Response"
- india.443.desc:0 "We have received a cowardly response from [From.GetLeader], stating a supposed lack of ressources as a justification why they will let millions die in vain. India won't forget this."
+ india.443.desc:0 "We have received a cowardly response from [From.GetLeader], stating a supposed lack of resources as a justification why they will let millions die in vain. India won't forget this."
  india.443.a:0 "Hell is upon us."
  colony_of_burma:0 "Colony of Burma"
  colony_of_burma_desc:0 "In 1937 the Colony of Burma was separated from the British Raj and it is no longer under its administration."

--- a/localisation/VEN_l_english.yml
+++ b/localisation/VEN_l_english.yml
@@ -558,7 +558,7 @@
  venezuela.4.c:0 "Rómulo Gallegos Knows What's Right For The Venezuelan People."
  venezuela.4.e:0 "Marcos Jiménez Will Give Venezuela a Strong Hand."
 
- venezuela.5.t:0 "[VEN.GetName] Propes Unification"
+ venezuela.5.t:0 "[VEN.GetName] Proposes Unification"
  venezuela.5.d:0 "After over a decade Venezuela wishes to once again join together with us to form a greater union. What should we do?"
  venezuela.5.a:0 "United we can revive Bolívar's legacy."
  venezuela.5.b:0 "Those glories are in the past now."


### PR DESCRIPTION
-Four typo/spelling fixes
-Fixed extend construction UI button position
-Austria can no longer unite with Germany if Germany did the Anschluß before (WTT event if Germany and Austria are democratic, will now almost never happen for r56 tree but that shouldnt be an issue), this prevents a 2nd Anschluß after Germany loses WW2 very early.
-Poland will ignore Germany taking Danzig city for the Soviet alliance focus if it was in return for an anti-Soviet pact (Danzig for guarantees)

-Separated the Dutch trade caving focuses and political focuses to allow for more flexibility especially with alt history UK/Germany (tooltips might be overly complicated for almost all situations but got me some practise with them)
