### PR TITLE
Tiny HOL focus alterations and state name fix

### DIFF
--- a/common/national_focus/netherlands.txt
+++ b/common/national_focus/netherlands.txt
@@ -1119,7 +1119,7 @@ focus_tree = {
 			has_war_with = GER
 			has_defensive_war = yes
 			GER = {
-				surrender_progress > 0.4
+				surrender_progress > 0.25
 			}
 		}
 

--- a/common/national_focus/netherlands_MtG.txt
+++ b/common/national_focus/netherlands_MtG.txt
@@ -1204,7 +1204,7 @@ focus_tree = {
 		available = {
 			has_war_with = GER
 			GER = {
-				surrender_progress > 0.4
+				surrender_progress > 0.25
 			}
 			has_capitulated = no
 			has_defensive_war = yes
@@ -1224,10 +1224,10 @@ focus_tree = {
 		}
 
         completion_reward = {
-			56 = { add_claim_by = HOL }
-			57 = { add_claim_by = HOL }
-			51 = { add_claim_by = HOL }
-			807 = { add_claim_by = HOL }
+			add_state_claim = 56
+			add_state_claim = 57
+			add_state_claim = 51
+			add_state_claim = 807
         }
 	}
 

--- a/common/national_focus/netherlands_MtG.txt
+++ b/common/national_focus/netherlands_MtG.txt
@@ -1193,10 +1193,10 @@ focus_tree = {
 	focus = {
 		id = HOL_the_new_ideal_MTG
 		icon = GFX_goal_HOL_the_new_ideal
-		prerequisite = {focus = HOL_liberation}
-		relative_position_id = HOL_liberation
-		x = 0
-		y = 1
+		prerequisite = { focus = HOL_foundations_for_a_european_union focus = HOL_request_allied_favors }
+		relative_position_id = HOL_american_west_indies_protectorate
+		x = 1
+		y = 2
 		cost = 2.5
 
 		available_if_capitulated = no
@@ -6459,11 +6459,11 @@ focus_tree = {
 			has_full_control_of_state = 309
 			has_full_control_of_state = 695
 		}
-		prerequisite = { focus = HOL_american_west_indies_protectorate }
+		prerequisite = { focus = HOL_allied_technological_developments }
 		icon = GFX_goal_generic_construct_military
 		x = 1
-		y = 2
-		relative_position_id = HOL_american_west_indies_protectorate
+		y = 1
+		relative_position_id = HOL_allied_technological_developments
 		cost = 10
 
 		available_if_capitulated = yes
@@ -6507,7 +6507,7 @@ focus_tree = {
 		prerequisite = { focus = HOL_unity_through_democracy }
 		mutually_exclusive = { focus = HOL_go_with_britain }
 		icon = GFX_goal_HOL_diplomacy
-		x = 2
+		x = 3
 		y = 1
 		relative_position_id = HOL_unity_through_democracy
 		cost = 10

--- a/localisation/HOL_l_english.yml
+++ b/localisation/HOL_l_english.yml
@@ -615,3 +615,6 @@
  HOL_communist_tt:0 "We must have either caved to communist influence or we shall be pursuing a different government type from our influencers in order to keep up our neutral policy."
  HOL_can_ENG_or_GER_influence_tt:0 "We are not currently in the process of transitioning to a different government type."
  HOL_is_placated_changing_gov_tt:0 "Is not currently undergoing a regime change."
+
+ #Missing MtG tree localization, copied from r56 tree loc
+ HOL_the_new_ideal_MTG_desc:0 "Germany has done too much damage to the world and to us in particular. They must now pay the price by moving their borders eastward." 

--- a/localisation/state_names_l_english.yml
+++ b/localisation/state_names_l_english.yml
@@ -33,7 +33,7 @@
  STATE_32:0 "Alpes"
  STATE_33:0 "Centre-Sud"
  STATE_34:0 "Wallonie"
- STATE_35:0 "Brabant"
+ STATE_35:0 "Noord-Brabant"
  STATE_36:0 "Friesland"
  STATE_37:0 "Sjaelland"
  STATE_38:0 "Norrland"


### PR DESCRIPTION
(all tested in-game then copy pasted)
Brabant -> Noord-Brabant
Prettier claims tooltip for the new ideal
Reused r56 tree localization for missing the new ideal loc in the MtG tree
Lowered capitulation progress requirement for the new ideal in both r56 and mtg trees
Moved the new ideal focus so it doesn't require moving the government to the East Indies

(Didn't change the event mentioned in waffles archives not sure what image would be better)