### PR TITLE
Fixing a thing no one cares about

### DIFF
--- a/common/units/names_ships/JAP_ship_names.txt
+++ b/common/units/names_ships/JAP_ship_names.txt
@@ -147,7 +147,7 @@ JAP_BB_HISTORICAL = {
 	fallback_name = "%d -go Senkan"
 
 	unique = {
-			"Kongo" "Hiei" "Yamato" "Musashi" "Tosa" "Kii" "Owari" "Iwami" "Sagami" "Suwo" "Hizen" "Tango" "Iki" 
+			"Kongo" "Yamato" "Musashi" "Tosa" "Kii" "Owari" "Iwami" "Sagami" "Suwo" "Hizen" "Tango" "Iki" 
 			# Captured/Converted/Older Models
 			"Fuso" "Yamashiro" "Ise" "Hyuga" "Nagato" "Mutsu" "Haruna" "Kirishima" "Kaga" "Shinano" 
 			# Fictional


### PR DESCRIPTION
"I was playing Hearts of Iron 4 as Japan, and while building superheavy battleships, I noticed that one was named Hiei.

Battleships in the IJN where named after ancient Japanese provinces, while battlecruisers where named after mountains in Japan.

Hiei is a mountain, and was historically the name of a Japanese battlecruiser.

So a superheavy battleship being named Hiei is incorrect because, following Japanese naming conventions, should have the name of an ancient Japanese province."
 The naming conventions will be consistent!