### PR TITLE
Preemptively nerfs the initiative bonus of marines for "No Step Back" release

### DIFF
--- a/common/units/infantry.txt
+++ b/common/units/infantry.txt
@@ -161,7 +161,7 @@ sub_units = {
 		weight = 0.5
 		supply_consumption = 0.06
 		breakthrough = 0.3
-		initiative = 0.1
+		initiative = 0.015
 	
 		need = {
 			infantry_equipment = 150


### PR DESCRIPTION
Noticed this was a RT56 specific change and decided that with the upcoming changes to initiative now being a major factor in [combat targeting](https://forum.paradoxplaza.com/forum/threads/hoi4-sub-developer-diary-combat-targeting-iteration.1493821/)

+10% initiative or a level 1 supply company per singular marine is already significantly pushing it because a regular 14-4 would have a +140% initiative bonus which would give the marine division a very power combat bonus when damaging a particular unit.