### PR TITLE
minor fix and localization

### DIFF
--- a/common/names/00_names.txt
+++ b/common/names/00_names.txt
@@ -2040,13 +2040,13 @@ INS_HOL = {
 
 INS = {
 	male = {
-		names = { Joko Fauzi Prabowo Ali Soemarno Henk Widji Teuku Hadi Azwar Mustafa Zaini Abdul Anak Ida Dewa }
+		names = { Joko Fauzi Prabowo Ali Soemarno Henk Widji Teuku Hadi Azwar Mustafa Zaini Abdul Agung Ida Dewa Eka Dwi Tri Eko Dharma Bayu Asep Abimanyu Budi Cecep Chandra Herman Hendra Jaret Muhammad Ahmad Septian Agus Okta Abdul Abdullah Faris Guntur Ridwan Satria Rano }
 	}
 	female = {
-		names = { Diah Siti }
+		names = { Diah Siti Tirta Eka Dwi Tri Malika Nadia Anggita Rahma Maemunah Anggi Agni Indri Citra Cantika Dian Dinda Ayu Indah Novi Febri Desi Asri Annisa Hayati Sri Devi Dewi }
 	}
-	surnames = { Widodo Bowo Subianto Sadikin Sosroatmodjo Ngantung Permatasari Damono Wibowo Thukul Hartinah Gunawan Haryanto Suprianto Sabara Abubakar "Bagus Oka" "Bagus Mantra" Martha}
-	callsigns = { }
+	surnames = { Widodo Bowo Subianto Sadikin Sosroatmodjo Ngantung Permatasari Damono Wibowo Thukul Hartinah Gunawan Haryanto Suprianto Sabara Abubakar "Bagus Oka" "Bagus Mantra" Martha Siswanto Junaedi Fajrianto Setiabudi Juanda Patrio Karno }
+	callsigns = { Jurig Pocong Kunti Tuyul Bima Yudhistira Arjuna Nakula Sadewa Maung Kijang Belalang "Walang Sangit" Kumbang Tongeret Jalak Elang Gagak Merpati Cenderawasih Rajawali Cungcuing Kalong Unyil "Wiro Sableng" "Si Pitung" Kabayan Kancil Makaji Sangkuriang Semar Gareng Petruk Bagong }
 }
 
 BHU = {

--- a/common/units/codenames_operatives/ENG_operative_codenames.txt
+++ b/common/units/codenames_operatives/ENG_operative_codenames.txt
@@ -1,4 +1,4 @@
-﻿#British Operative list
+﻿﻿#British Operative list
 ENG_OPERATIVE_CODENAME_HISTORICAL = {
 	name = ENG_HISTORICAL_OPERATIVES
 
@@ -49,6 +49,7 @@ ENG_OPERATIVE_CODENAME_HISTORICAL = {
 		"Sweep"
 		"Sooty"
 		"Snuffles"
+		
 		
 
 	}

--- a/common/units/codenames_operatives/INS_operative_codenames.txt
+++ b/common/units/codenames_operatives/INS_operative_codenames.txt
@@ -1,0 +1,42 @@
+﻿#Indonesian Operative list
+INS_OPERATIVE_CODENAME_HISTORICAL = {
+	name = INS_HISTORICAL_OPERATIVES
+
+	# for Indonesia
+	for_countries = { INS }
+
+	type = codename
+
+	fallback_name = "Agent %d"
+
+	unique = {
+
+
+		"Semar"
+		"Gareng"
+		"Petruk"
+		"Bagong"
+		"Bima"
+		"Arjuna"
+		"Yudhistira"
+		"Nakula"
+		"Sadewa"
+		"Sangkuriang"
+		"Unyil"
+		"Wiro Sableng"
+		"Kancil"
+		"Kabayan"
+		"Makaji"
+		"Gundala"
+		"Kalong"
+		"Godam"
+		"Beruang"
+		"Kijang"
+		"Ular"
+		"Badak"
+		"Gajah"
+		
+		
+
+	}
+}

--- a/common/units/names/00_names.txt
+++ b/common/units/names/00_names.txt
@@ -5816,53 +5816,53 @@ POL = {
 }
 
 INS = {
-	submarine = {
+	Submarine = {
 		prefix = "KRI"
-		generic = { "Submarine" }
+		generic = { "Kapal Selam" }
 		unique = {
-			"Nagapasa" "Ardadedali" "Alugoro" "Cakra" "Nanggala"
+			"Nagapasa" "Ardadedali" "Cakra" "Nanggala" "Nagabanda" "Trisula" "Nagarangsang" "Tjandrasa" "Alugoro" "Tjumandani" "Widjajadanu" "Pasopati" "Hendradjala" "Bramastra" "XXX" "YYY"
 		}
 	}
 	destroyer = {
 		prefix = "KRI"
-		generic = { "Destroyer" }
+		generic = { "Perusak" }
 		unique = {
-			"Mandau" "Rencong" "Badik" "Keris" "Todak" "Hiu" "Layang" "Lemadang" "Pandrong" "Sura" "Clurit" "Kujang" "Beladau" "Alamang" "Parang" "Siwar" "Surik" "Terapang" "Sampari" "Tombak" "Halasan" "Badau" "Selawaku" "Ajak" "Andau" "Singa" "Tongkak" "Kakap" "Kerapu" "Tongkol" "Barakuda" "Boa" "Welang"
+			"Gadjah Mada" "Brawidjaja" "Sawunggaling" "Sultan Iskandar Muda" "Diponegoro" "Sisingamaradja" "Siliwangi" "Sandjaja" "Sarwadjala" "Surapati" "Imam Bondjol" "Adjak" "Anoa" "Beruang" "Harimau" "Matjan Kumbang" "Matjan Tutul" "Serigala" "Singa" "Rencong" "Badik" "Keris" "Todak" "Hiu" "Layang" "Lemadang" "Pandrong" "Sura" "Clurit" "Kujang" "Beladau" "Alamang" "Parang" "Siwar" "Surik" "Terapang" "Sampari" "Tombak" "Halasan" "Badau" "Selawaku" "Ajak" "Andau" "Singa" "Tongkak" "Kakap" "Kerapu" "Tongkol" "Barakuda" "Tenggiri" "Tjakalang 807" "Torani" "Alu Alu" "Boa" "Welang" "Mandau"
 		}
 	}
 	light_cruiser = {
 		prefix = "KRI"
-		generic = { "Light Cruiser" }
+		generic = { "Penjelajah Ringan" }
 		unique = {
-			"Diponegoro" "Sultan Hasanuddin" "Sultan Iskandar Muda" "Frans Kaisiepo" "Bung Tomo" "John Lie" "Usman Harun" "Fatahillah" "Malahayati" "Nala" " Kapitan Pattimura" "Untung Suropati" "Nuku" "Lambung Mangkurat" "Cut Nyak Dien" "Sultan Thaha Syaifudin" "Sutanto" "Sutedi Senoputra" "Wiratno" "Tjiptadi" "Hasan Basri" "Imam Bonjol" "Teuku Umar" "Silas Papare"
+			"Sultan Hasanuddin" "Frans Kaisiepo" "Bung Tomo" "John Lie" "Usman Harun" "Fatahillah" "Malahayati" "Nala" " Kapitan Pattimura" "Untung Suropati" "Nuku" "Lambung Mangkurat" "Cut Nyak Dien" "Sultan Thaha Syaifudin" "Sutanto" "Sutedi Senoputra" "Wiratno" "Tjiptadi" "Hasan Basri" "Teuku Umar" "Silas Papare"
 		}
 	}
 	heavy_cruiser = {
 		prefix = "KRI"
-		generic = { "Heavy Cruiser" }
+		generic = { "Penjelajah Berat" }
 		unique = {
-			"Raden Edi Martadinata" "I Gusti Ngurah Rai" "Diponegoro" "Ahmad Yani" "Slamet Riyadi" "Yos Sudarso" "Oswald Siahaan" "Abdul Halim Perdanakusuma" "Karel Satsuit Tubun"
+			"Raden Edi Martadinata" "I Gusti Ngurah Rai" "Ahmad Yani" "Slamet Riyadi" "Jos Sudarso" "Oswald Siahaan" "Abdul Halim Perdanakusuma" "Karel Satsuit Tubun"
 		}
 	}
 	battle_cruiser = {
 		prefix = "KRI"
-		generic = { "Battle Cruiser" }
+		generic = { "Penjelajah Tempur" }
 		unique = {
-			"Jakarta" "Bandung" "Semarang" "Surabaya" "Malang" 
+			"Jakarta" "Bandung" "Semarang" "Surabaya" "Malang" "Lampung" "Denpasar" "Meikarta" "Djogjakarta" "Bekasi" "Cimahi" "Cianjur" "Mataram" "Sabang" "Merauke" "Denpasar" "Sorong"  
 		}
 	}
 	battleship = {
 		prefix = "KRI"
-		generic = { "Battleship" }
+		generic = { "Kapal Tempur" }
 		unique = {
-			"Palembang" "Balikpapan" "Makassar" "Padang" "Medan" 
+			"Palembang" "Balikpapan" "Makassar" "Padang" "Medan" "Sumatra" "Jawa" "Kalimantan" "Sulawesi" "Nusa Tenggara" "Papua" "Maluku" "Aceh" "Bali" "Banten" "Bangka Belitung" "Jambi" "Bengkulu" "Gorontalo"
 		}
 	}
 	carrier = {
 		prefix = "KRI"
-		generic = { "Carrier" }
+		generic = { "Kapal Induk" }
 		unique = {
-			"Sumatra" "Java" "Kalimantan" "Sulawesi" "Nusa Tenggara" "Papua" "Maluku" "Aceh"
+			"Elang" "Rajawali" "Jalak" "Cenderawasih" "Gagak" "Kasuari" "Merpati" "Kakaktua" "Cungcuing" "Garuda" "Sangkuriang" "Gatot Kaca" "Rama" "Si Pitung" "Kabayan" "Unyil" "Timun Mas" "Wiro Sableng" "Pandawa" "Semar" "Gareng" "Petruk"
 		}
 	}
 }

--- a/common/units/names_divisions/INS_names_divisions.txt
+++ b/common/units/names_divisions/INS_names_divisions.txt
@@ -1,0 +1,208 @@
+﻿INS_INF_05 = {
+	name = "TKR Infantry Division"
+	for_countries = { INS }
+	can_use = { always = yes }
+	division_types = { "infantry" }
+	fallback_name = "Divisi %d TKR"
+	ordered = {
+		1 = { "Divisi %d TKR" }
+		11 = { "Divisi 1 TKR Sumatra" }
+		21 = { "Divisi 1 TKR Kalimantan" }
+		31 = { "Divisi 1 TKR Sulawesi" }
+		41 = { "Divisi 1 TKR Bali" }
+		51 = { "Divisi 1 TKR Nusa Tenggara" }
+		61 = { "Divisi 1 TKR Papua" }
+		71 = { "Divisi %d TKR" }
+		81 = { "Divisi %d TKR" }
+		91 = { "Divisi %d TKR" }
+		101 = { "Divisi %d TKR" }
+		2 = { "Divisi %d TKR" }
+		12 = { "Divisi 2 TKR Sumatra" }
+		22 = { "Divisi 2 TKR Kalimantan" }
+		32 = { "Divisi 2 TKR Sulawesi" }
+		42 = { "Divisi 2 TKR Bali" }
+		52 = { "Divisi 2 TKR Nusa Tenggara" }
+		62 = { "Divisi 2 TKR Papua" }
+		72 = { "Divisi %d TKR" }
+		82 = { "Divisi %d TKR" }
+		92 = { "Divisi %d TKR" }
+		102 = { "Divisi %d TKR" }
+		3 = { "Divisi %d TKR" }
+		13 = { "Divisi 3 TKR Sumatra" }
+		23 = { "Divisi 3 TKR Kalimantan" }
+		33 = { "Divisi 3 TKR Sulawesi" }
+		43 = { "Divisi 3 TKR Bali" }
+		53 = { "Divisi 3 TKR Nusa Tenggara" }
+		63 = { "Divisi 3 TKR Papua" }
+		73 = { "Divisi %d TKR" }
+		83 = { "Divisi %d TKR" }
+		93 = { "Divisi %d TKR" }
+		103 = { "Divisi %d TKR" }
+		4 = { "Divisi %d TKR" }
+		14 = { "Divisi 4 TKR Sumatra" }
+		24 = { "Divisi 4 TKR Kalimantan" }
+		34 = { "Divisi 4 TKR Sulawesi" }
+		44 = { "Divisi 4 TKR Bali" }
+		54 = { "Divisi 4 TKR Nusa Tenggara" }
+		64 = { "Divisi 4 TKR Papua" }
+		74 = { "Divisi %d TKR" }
+		84 = { "Divisi %d TKR" }
+		94 = { "Divisi %d TKR" }
+		104 = { "Divisi %d TKR" }
+		5 = { "Divisi %d TKR" }
+		15 = { "Divisi 5 TKR Sumatra" }
+		25 = { "Divisi 5 TKR Kalimantan" }
+		35 = { "Divisi 5 TKR Sulawesi" }
+		45 = { "Divisi 5 TKR Bali" }
+		55 = { "Divisi 5 TKR Nusa Tenggara" }
+		65 = { "Divisi 5 TKR Papua" }
+		75 = { "Divisi %d TKR" }
+		85 = { "Divisi %d TKR" }
+		95 = { "Divisi %d TKR" }
+		105 = { "Divisi %d TKR" }
+		6 = { "Divisi %d TKR" }
+		16 = { "Divisi 6 TKR Sumatra" }
+		26 = { "Divisi 6 TKR Kalimantan" }
+		36 = { "Divisi 6 TKR Sulawesi" }
+		46 = { "Divisi 6 TKR Bali" }
+		56 = { "Divisi 6 TKR Nusa Tenggara" }
+		66 = { "Divisi 6 TKR Papua" }
+		76 = { "Divisi %d TKR" }
+		86 = { "Divisi %d TKR" }
+		96 = { "Divisi %d TKR" }
+		106 = { "Divisi %d TKR" }
+	}
+}
+INS_INF_06 = {
+	name = "TNI Infantry Division"
+	for_countries = { INS }
+	can_use = { always = yes }
+	division_types = { "infantry" }
+	fallback_name = "Divisi Infanteri %d"
+	ordered = {
+		1 = { "Divisi Infanteri %d Kostrad Cilodong" }
+		2 = { "Divisi Infanteri %d Kostrad Singosari" }
+		3 = { "Divisi Infanteri %d Kostrad Bontomarannu" }
+	}
+}
+INS_ART_01 = {
+	name = "TNI Artillery Division"
+	for_countries = { INS }
+	can_use = { always = yes }
+	division_types = { "artillery" }
+	fallback_name = "Divisi Artileri %d"
+	ordered = {
+		1 = { "Divisi Artileri %d Sthira Yudha" }
+		2 = { "Divisi Artileri %d Putra Yudha" }
+		6 = { "Divisi Artileri %d Tamarunang" }
+		9 = { "Divisi Artileri %d Pasopati" }
+		10 = { "Divisi Artileri %d Brajamusti" }
+		11 = { "Divisi Artileri %d Guntur Geni Yudha" }
+		12 = { "Divisi Artileri %d Angicipi Yudha" }
+		13 = { "Divisi Artileri %d Nanggala" }
+	}
+}
+INS_PAR_05 = {
+	name = "TNI Paratrooper Division"
+	for_countries = { INS }
+	can_use = { always = yes }
+	division_types = { "infantry" }
+	fallback_name = "Divisi Para Raider %d"
+	ordered = {
+		1 = { "Divisi Para Raider %d Tengkorak" }
+		2 = { "Divisi Para Raider %d Dirgahayu" }
+		3 = { "Divisi Para Raider %d Tri Dharma" }
+		4 = { "Divisi Para Raider %d Bajra Yudha" }
+		5 = { "Divisi Para Raider %d Ujwala Yudha" }
+		6 = { "Divisi Para Raider %d Mayangkara" }
+		7 = { "Divisi Para Raider %d Satria Setia Perkasa" }
+		8 = { "Divisi Para Raider %d Julu Siri" }
+		17 = { "Divisi Para Raider %d Sakti Budi Bhakti" }
+		18 = { "Divisi Para Raider %d Sarvatra Eva Yudha" }
+	}
+}
+INS_MEC_05 = {
+	name = "TNI Mechanized Division"
+	for_countries = { INS }
+	can_use = { always = yes }
+	division_types = { "mechanized" }
+	fallback_name = "Divisi Mekanis %d"
+	ordered = {
+		1 = { "Divisi Mekanis %d Pendawa" }
+		2 = { "Divisi Mekanis %d Bharata Eka Sakti" }
+		3 = { "Divisi Mekanis %d Bremoro" }
+		4 = { "Divisi Mekanis %d Bala Turangga Cakti" }
+		3 = { "Divisi Mekanis %d Serigala Ceta" }
+		6 = { "Divisi Mekanis %d Shima Pasupati" }
+		7 = { "Divisi Mekanis %d Birgus Latro Cakti" }
+		8 = { "Divisi Mekanis %d Galuh" }
+		9 = { "Divisi Mekanis %d Setia Sampai Mati" }
+		10 = { "Divisi Mekanis %d Galuh Taruna" }
+		11 = { "Divisi Mekanis %d Buaya Putih" }
+		12 = { "Divisi Mekanis %d Dharaka Yudha" }
+	}
+}
+INS_ARM_05 = {
+	name = "TNI Armored Division"
+	for_countries = { INS }
+	can_use = { always = yes }
+	division_types = { "armor" }
+	fallback_name = "Divisi Tank %d"
+	ordered = {
+		1 = { "Divisi Tank %d Badak Ceta Cakti" }
+		2 = { "Divisi Tank %d Turangga Ceta" }
+		3 = { "Divisi Tank %d Andhaka Cakti" }
+		4 = { "Divisi Tank %d Kijang Cakti" }
+		5 = { "Divisi Tank %d Dwipangga Ceta" }
+		6 = { "Divisi Tank %d Naga Karimatai" }
+		7 = { "Divisi Tank %d Pragosa Satya" }
+		8 = { "Divisi Tank %d Narasinga Wiratama" }
+		9 = { "Divisi Tank %d Satya Dharma Kala" }
+		10 = { "Divisi Tank %d Mendagiri" }
+		11 = { "Divisi Tank %d Macan Setia Cakti" }
+		12 = { "Divisi Tank %d Beruang Cakti" }
+		13 = { "Divisi Tank %d Satya Lembuswana" }
+	}
+}
+INS_MAR_05 = {
+	name = "TNI Marine Division"
+	for_countries = { INS }
+	can_use = { always = yes }
+	division_types = { "infantry" }
+	fallback_name = "Satuan Kopaska %d"
+	ordered = {
+		1 = { "Satuan Kopaska %d Jakarta" }
+		2 = { "Satuan Kopaska %d Surabaya" }
+		3 = { "Satuan Kopaska %d Sorong" }
+		4 = { "Satuan Kopaska %d Raja Ampat" }
+		5 = { "Satuan Kopaska %d Cimahi" }
+		6 = { "Satuan Kopaska %d Lampung" }
+		7 = { "Satuan Kopaska %d Denpasar" }
+		8 = { "Satuan Kopaska %d Mataram" }
+		9 = { "Satuan Kopaska %d Aceh" }
+		10 = { "Satuan Kopaska %d Riau" }
+		11 = { "Satuan Kopaska %d Makassar" }
+		12 = { "Satuan Kopaska %d Palembang" }
+	}
+}
+INS_INF_07 = {
+	name = "TNI Special Forces Division"
+	for_countries = { INS }
+	can_use = { always = yes }
+	division_types = { "infantry" }
+	fallback_name = "Satuan Kopassus %d"
+	ordered = {
+		1 = { "Satuan Kopassus %d Serang" }
+		2 = { "Satuan Kopassus %d Kartasura" }
+		3 = { "Satuan Kopassus %d Batujajar" }
+		4 = { "Satuan Kopassus %d Cijantung" }
+		5 = { "Satuan Kopassus %d Cimahi" }
+		6 = { "Satuan Kopassus %d Lampung" }
+		7 = { "Satuan Kopassus %d Denpasar" }
+		8 = { "Satuan Kopassus %d Mataram" }
+		9 = { "Satuan Kopassus %d Aceh" }
+		10 = { "Satuan Kopassus %d Riau" }
+		11 = { "Satuan Kopassus %d Makassar" }
+		12 = { "Satuan Kopassus %d Palembang" }
+	}
+}

--- a/history/countries/INS - Indonesia.txt
+++ b/history/countries/INS - Indonesia.txt
@@ -133,6 +133,17 @@ create_country_leader = {
 }
 
 create_country_leader = {
+	name = "Hasjim Asy'ari"
+	desc = ""
+	picture = "gfx/leaders/INS/r56_portrait_INS_Hasyim_Asyari.dds"
+	expire = "1953.3.1"
+	ideology = islamic_democracy
+	traits = {
+		
+	}
+}
+
+create_country_leader = {
 	name = "A. T. van Starkenborgh Stachouwer"
 	desc = ""
 	picture = "GFX_portrait_indonesia_at_van_starkenborgh"

--- a/localisation/replace/parties_l_english.yml
+++ b/localisation/replace/parties_l_english.yml
@@ -519,8 +519,8 @@
  CAM_neutrality_party:0 "Sangkum Reastr Niyum" # or just Sangkum 1955, democratic but right leaning and anti communist
  INS_fascist_party:0 "PNI" #inspired by right wingers from 1960s
  INS_fascist_party_long:0 "Partai Nasional Indonesia"
- INS_democracy_party:0 "PSI" #Indonesian National Party founded by Sukarno
- INS_democracy_party_long:0 "Partai Sosialis Indonesia" 
+ INS_democracy_party:0 "Masyumi"
+ INS_democracy_party_long:0 "Majelis Syuro Muslimin Indonesia" #existed before PSI
  INS_communist_party:0 "PKI" #Partai Komunis Indonesia
  INS_communist_party_long:0 "Partai Komunis Indonesia"
  INS_neutrality_party:0 "Colonial Government"


### PR DESCRIPTION
Added names for ships, divisions, and people, added missing democratic version of Hasjim Asy'ari (he founded Masyumi, then split and formed NU after an ideological disagreement).

Updated ship names:
- Submarines: historical submarines
- Destroyers: historical destroyers, speedboats, and patrol boats
- Cruisers: cities
- Battleships: provinces
- Carriers: birds and mythological/cultural figures