### PR TITLE
Nerfs militia a bit more

### DIFF
--- a/common/decisions/r56_generic_decisions.txt
+++ b/common/decisions/r56_generic_decisions.txt
@@ -488,13 +488,14 @@ political_actions = {
 						has_government = democratic
 					}
 				}
-				has_war_support > 0.30
+				OR = {
+					has_defensive_war = yes
+					surrender_progress > 0.25
+				}
 			}
 			else = {
 				OR = {
-					has_defensive_war = yes
-					has_war_support > 0.5
-					surrender_progress > 0.20
+					surrender_progress > 0.35
 				}
 			}
 			command_power > 24
@@ -514,7 +515,7 @@ political_actions = {
 			command_power > 24
 		}
 
-		days_remove = 90
+		days_remove = 25
 
 		remove_effect = {
 			hidden_effect = {

--- a/common/units/r56_units.txt
+++ b/common/units/r56_units.txt
@@ -36,12 +36,12 @@ sub_units = {
 
 
 		#Offensive Abilities
-		soft_attack = 0.7 #We'll need a bunch more training to be able to compete with infantry in stats per infantry equipment spent
-		hard_attack = 0.7
+		soft_attack = -0.3 #We'll need a bunch more training to be able to compete with infantry in stats per infantry equipment spent
+		hard_attack = -0.3
 
 		#Defensive Abilities
-		defense = 0.7 #We'll need a bunch more training to be able to compete with infantry in stats per infantry equipment spent
-		breakthrough = 0.7
+		defense = -0.3 #We'll need a bunch more training to be able to compete with infantry in stats per infantry equipment spent
+		breakthrough = -0.3
 		hardness = 0
 		armor_value = 0
 

--- a/common/units/r56_units.txt
+++ b/common/units/r56_units.txt
@@ -24,56 +24,60 @@ sub_units = {
 		combat_width = 2
 		
 		#Misc Abilities
-		training_time = 50 #Grab your friends and some guns
-		max_strength = 20
+		training_time = 30 #Grab your friends and some guns
+		max_strength = 10
 		max_organisation = 40
 		default_morale = 0.2
-		maximum_speed = 0.4
-		manpower = 1000
+		maximum_speed = 0.35 #Countered by terrain changes + no combo'ing with other units in the same template
+		manpower = 1400 #More manpower than infantry equipment vs infantry
 		supply_consumption = 0.05 #We're low maintance
 		suppression = 0.1 #We cannot police worth shit
 		weight = 0.5
 
 
+		#Offensive Abilities
+		soft_attack = 0.7 #We'll need a bunch more training to be able to compete with infantry in stats per infantry equipment spent
+		hard_attack = 0.7
+
 		#Defensive Abilities
-		defense = 0.04 #Defending? We can do that
-		breakthrough = 0.01
+		defense = 0.7 #We'll need a bunch more training to be able to compete with infantry in stats per infantry equipment spent
+		breakthrough = 0.7
 		hardness = 0
 		armor_value = 0
 
 	
 		amphibious = {
 			attack = -0.95 #We get seasick
-			movement = -0.95 #We get seasick
+			movement = -0.65 #We get seasick
 		}
 		river = {
-			attack = -0.35 
+			attack = -0.15
 			movement = -0.35
 		}
 		marsh = {
-			attack = -0.35
+			attack = -0.15
 			movement = -0.35
 		}
 		desert = {
-			attack = -0.35 #My shoes are sandy
+			attack = -0.15 #My shoes are sandy
 			movement = -0.35 #My shoes are sandy
 		}
 		jungle = {
-			attack = -0.35 #My shoes are wet
+			attack = -0.15 #My shoes are wet
 			movement = -0.35 #My shoes are wet
 		}
 		mountain = {
-			attack = -0.35 #You want us to climb that?
+			attack = -0.15 #You want us to climb that?
 			movement = -0.35 #You want us to climb that?
 		}
 		urban = {
-			attack = -0.35 #Urban assualt is above my paygrade
+			attack = -0.15 #Urban assualt is above my paygrade
 		}
 		forest = {
 			movement = -0.35
 		}
 		fort = {
-			attack = -0.35
+			attack = -0.15
 		}
 		hills = {
 			movement = -0.35


### PR DESCRIPTION
This mainly exists because a community centered around a mod based off of RT56 was complaining about militia being overpowered, this is here for the RT56 developers if they're interested in implementing these changes.

### **Main changes and reasoning**

Reduced attack/defense stats militia; In my opinion, they shouldn't have more stats : IC efficiency than infantry, with this change militia will be mostly a downgrade of infantry until they have acquired much more experience through field training and combat

Increased manpower cost; trade off for having a cheaper IC division

Reduced HP/strength; discourages hoarding an entire army of militia after a war by making it less economically efficient than just having infantry

Decision activation changes; you must now be actively losing a bunch of your land to actually enable militias to begin training rather than having a pre-war army composed of mostly militia. In exchange for this, a reduced duration before one can begin training the militia is implemented.