### PR TITLE
Fix Militia Icons On Linux

### DIFF
--- a/interface/replace/r56_texticons.gfx
+++ b/interface/replace/r56_texticons.gfx
@@ -4,14 +4,14 @@ spriteTypes = {
 	
 	spriteType = {
 		name = "GFX_unit_militia_icon_small"
-		texturefile = "gfx/texticons/unit_militia_icon_small.dds"
+		texturefile = "gfx/texticons/unit_Militia_icon_small.dds"
 		legacy_lazy_load = no
 		noOfFrames = 2
 	}
 	
 	spriteType = {
 		name = "GFX_nato_unit_militia_icon_small"
-		texturefile = "gfx/texticons/nato_unit_militia_icon_small.dds"
+		texturefile = "gfx/texticons/nato_unit_Militia_icon_small.dds"
 		legacy_lazy_load = no
 	}
 


### PR DESCRIPTION
Due to case-sensitivity on Linux, this should fix the militia icons missing on Linux.