### PR TITLE
Implements NSB armor upgrades

### DIFF
--- a/common/units/equipment/upgrades/land_upgrades.txt
+++ b/common/units/equipment/upgrades/land_upgrades.txt
@@ -1,5 +1,93 @@
 upgrades = {
-	
+
+	tank_nsb_engine_upgrade = {
+		abbreviation = "eng"
+		max_level = 20 #each level represents ~50HP
+		cost = land
+
+		linear_cost = {
+			cost_by_level = 1
+			cost_by_level_for_licensed_equipment = 5
+		}
+
+		level_requirements = {
+			5 = {
+				has_tech = engine_tech_1
+			}
+			10 = {
+				has_tech = engine_tech_2
+			}
+			15 = {
+				has_tech = engine_tech_3
+			}
+			18 = { 
+				has_tech = engine_tech_4
+			}
+		}
+
+		resource_cost_thresholds = {
+			10 = { #higher level engines do require more strategic resources
+				chromium = 1
+			}
+		}
+
+		maximum_speed = 0.1
+		reliability = -0.02
+		add_stats = {
+			fuel_consumption = 0.05
+			build_cost_ic = 0.1
+		}
+	}
+
+	tank_nsb_armor_upgrade = {
+		abbreviation = "arm"
+		max_level = 20 #each level represents ~10mm of armor 
+		cost = land
+
+		linear_cost = {
+			cost_by_level = 1
+			cost_by_level_for_licensed_equipment = 2
+		}
+
+		level_requirements = {
+			5 = {
+				has_tech = armor_tech_1
+			}
+			10 = {
+				has_tech = armor_tech_2
+			}
+			15 = {
+				has_tech = armor_tech_3
+			}
+			18 = {
+				has_tech = armor_tech_4
+			}
+		}
+
+		resource_cost_thresholds = { # resource values defined here are TOTAL added cost, not cumulative
+			5 = { #more armor requires more resources
+				steel = 1 
+			}
+			10 = {
+				steel = 2
+				chromium = 1
+			}
+			15 = {
+				steel = 2
+				chromium = 2
+			}
+		}
+
+		maximum_speed = -0.05
+		reliability = -0.02
+		armor_value = 0.075
+		add_stats = {
+			breakthrough = 1.25
+			build_cost_ic = 0.25
+
+		}
+	}
+
 	tank_gun_upgrade = {
 		max_level = 5
 
@@ -32,7 +120,12 @@ upgrades = {
 		max_level = 5
 		cost = land
 		reliability = 0.1
-		build_cost_ic = 0.02
+	}
+	mech_cost_upgrade = {
+		max_level = 5
+		cost = land
+		build_cost_ic = -0.1
+		reliability = -0.05
 	}
 	tank_aa_upgrade = {
 		max_level = 5


### PR DESCRIPTION
Should fix errors related to the following

[19:50:56][ai_equipment_strategy.cpp:594]: common/ai_equipment/ENG_tank.txt:1422: ai design entry advanced_heavy_tank_default mentions upgrade tank_nsb_armor_upgrade that does not exist in equipment heavy_tank_chassis_3
