### PR TITLE
Unimplemented boat class fixed

### DIFF
--- a/history/countries/ENG - Britain.txt
+++ b/history/countries/ENG - Britain.txt
@@ -105,6 +105,7 @@ if = {
 	}
 	set_technology = {
 		early_submarine = 1
+		basic_submarine = 1
 		early_destroyer = 1
 		basic_destroyer = 1
 		early_light_cruiser = 1
@@ -127,6 +128,7 @@ if = {
 		early_ship_hull_light = 1
 		basic_ship_hull_light = 1
 		early_ship_hull_submarine = 1
+		basic_ship_hull_submarine = 1
 		early_ship_hull_cruiser = 1
 		basic_ship_hull_cruiser = 1
 		early_ship_hull_heavy = 1

--- a/history/units/ENG_1936_Naval.txt
+++ b/history/units/ENG_1936_Naval.txt
@@ -240,7 +240,7 @@
 			location = 9458 # Portsmouth
 			# Submarine Division 51
 			ship = { name = "HMS Oberon" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = ENG version_name = "O/P/R Class" } } }
-			ship = { name = "HMS Thames" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = ENG version_name = "O/P/R Class" } } }
+			ship = { name = "HMS Thames" definition = submarine equipment = { ship_hull_submarine_2 = { amount = 1 owner = ENG version_name = "River Class" } } }
 			# Submarine Division 52
 			ship = { name = "HMS L23" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = ENG version_name = "O/P/R Class" } } }
 			ship = { name = "HMS H28" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = ENG version_name = "O/P/R Class" } } }
@@ -373,8 +373,8 @@
 			name = "3rd Submarine Flotilla"			
 			location = 2038 # Sierra Leone
 			# Submarine Division 71
-			ship = { name = "HMS Severn" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = ENG version_name = "O/P/R Class" } } }		
-			ship = { name = "HMS Clyde" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = ENG version_name = "O/P/R Class" } } }		
+			ship = { name = "HMS Severn" definition = submarine equipment = { ship_hull_submarine_2 = { amount = 1 owner = ENG version_name = "River Class" } } }		
+			ship = { name = "HMS Clyde" definition = submarine equipment = { ship_hull_submarine_2 = { amount = 1 owner = ENG version_name = "River Class" } } }		
 		}
 	}
 


### PR DESCRIPTION
Assigned the boats belonging to the River Class to this in-game class. And updated the starting techs to match this 1936 class being unlocked. For non-DLC the classes are different, but the techs it seems were also non-matching.