### PR TITLE
Added Catalan to Juan Pujol's nationalities

### DIFF
--- a/history/countries/ENG - Britain.txt
+++ b/history/countries/ENG - Britain.txt
@@ -478,7 +478,7 @@ if = {
 		traits = { operative_double_agent }
 		bypass_recruitment = no
 		available_to_spy_master = yes
-		nationalities = { ENG GER SPR }
+		nationalities = { ENG GER SPR CAT }
 	}
 
 	create_operative_leader = {


### PR DESCRIPTION
Juan Pujol was born and raised in Barcelona to a Catalan mother. This in line with Dusko Popov's Serbian nationality.