### PR TITLE
Issue 2251 cv jet fighter missions

### DIFF
--- a/common/units/air.txt
+++ b/common/units/air.txt
@@ -35,15 +35,6 @@ sub_units = {
 		need = { jet_fighter_equipment = 1 }
 		categories = { category_fighter }
 	}
-	
-	cv_jet_fighter = {
-		sprite = jet_plane
-		priority = 1
-		active = yes
-		type = { fighter cas }
-		need = { cv_fighter_equipment = 1 }
-		categories = { category_fighter }
-	}
 
 	cas = {
 		sprite = light_plane

--- a/common/units/air.txt
+++ b/common/units/air.txt
@@ -22,7 +22,7 @@ sub_units = {
 		sprite = light_plane
 		priority = 1
 		active = yes
-		type = { fighter }
+		type = { fighter cas }
 		need = { cv_fighter_equipment = 1 }
 		categories = { category_fighter }
 	}


### PR DESCRIPTION
### Summary
Issue: #2251  
[kmjohnsonpgh](https://github.com/kmjohnsonpgh) noticed despite having values for ground and naval attack, cv jet fighters were not able to perform the missions which r56 fighters can.  

Taking a look, I noticed that all r56 cv fighters have values for ground and naval attack but regular cv fighters were **also** not about to perform these missions.  
This looks like it is caused by cv_fighter units not having the `cas` type. I added the `cas` type to `cv_fighter` in air.txt. I'm not sure why `cv_jet_fighter` did have `cas` but `cv_fighter` did not. I assumed it was supposed to since `cv_fighter_equipment*` has cas values.

I also removed the `cv_jet_fighter` unit since it appears to not be used. I assume this is because `jet_fighter` uses a different equipment archetype as `fighter` so that fighters don't upgrade to jet fighters, which is different behavior than CV jet fighters which do replace prop cv fighters.

### Testing
I tested this locally on my own machine with no other mods than this branch of 1956_beta and it doesn't crash. Here's what that looks like  
![cv_fighters](https://user-images.githubusercontent.com/70606111/171111863-bc58fd5f-45f1-4347-9aa7-825c3a6dac86.jpg)

I did not test these changes in actual combat or naval combat, which someone should do eventually.

