### PR TITLE
Removed Adv Light Tank from Modern Tank req.

### DIFF
--- a/common/technologies/NSB_armor.txt
+++ b/common/technologies/NSB_armor.txt
@@ -428,11 +428,6 @@ technologies = {
 			light_tank_aa_chassis_3
 		}
 
-		path = {
-			leads_to_tech = main_battle_tank_chassis
-			research_cost_coeff = 1
-		}
-
 		research_cost = 2
 		start_year = 1941
 


### PR DESCRIPTION
This change is one made from PDX and has yet to be implemented in our mod.