### PR TITLE
Fixes for Soviets - The Right Opposition

### DIFF
--- a/common/characters/SOV.txt
+++ b/common/characters/SOV.txt
@@ -3561,7 +3561,8 @@ characters = {
 					NOT = { has_idea = SOV_nikolay_yezhov }
 					NOT = { has_idea = SOV_genrikh_yagoda }
 					NOT = { is_country_leader = yes }
-					has_country_leader = { name = "Nikita Khrushchev" ruling_only = yes } #for Grieving Stalin
+					#-> Having this check (Nikita Khrushchev) breaks third (last possible) NKVD head purge - it would immediatelly remove this advisor <><>
+					#has_country_leader = { name = "Nikita Khrushchev" ruling_only = yes } #for Grieving Stalin
 				}
 
 				traits = {

--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -12368,21 +12368,41 @@ focus_tree = {
 				IF = {
 					limit = { SOV_is_right_opposition = yes }
 					every_character = {
-						limit = {
-							has_character_flag = SOV_exiled_flag
-							has_character_flag = SOV_aligned_left_opposition_flag
+						IF = {
+							limit = {
+								has_character_flag = SOV_exiled_flag
+								has_character_flag = SOV_aligned_left_opposition_flag
+							}
+							clr_character_flag = SOV_exiled_flag
 						}
-						clr_character_flag = SOV_exiled_flag
+						#-> Without this, only Lev Trotsky is available, because the other ones from the Left are still in prison <><>
+						IF = {
+							limit = {
+								has_character_flag = SOV_imprisoned_flag
+								has_character_flag = SOV_aligned_left_opposition_flag
+							}
+							clr_character_flag = SOV_imprisoned_flag
+						}
 					}
 				}
 				ELSE_IF = {
 					limit = { SOV_is_left_opposition = yes }
 					every_character = {
-						limit = {
-							has_character_flag = SOV_exiled_flag
-							has_character_flag = SOV_aligned_right_opposition_flag
+						IF = {
+							limit = {
+								has_character_flag = SOV_exiled_flag
+								has_character_flag = SOV_aligned_right_opposition_flag
+							}
+							clr_character_flag = SOV_exiled_flag
 						}
-						clr_character_flag = SOV_exiled_flag
+						#-> Unsure if anyone from the Right is in prison - won't hurt to check <><>
+						IF = {
+							limit = {
+								has_character_flag = SOV_imprisoned_flag
+								has_character_flag = SOV_aligned_right_opposition_flag
+							}
+							clr_character_flag = SOV_imprisoned_flag
+						}
 					}
 				}
 			}

--- a/events/LAR_NewsEvents.txt
+++ b/events/LAR_NewsEvents.txt
@@ -574,6 +574,25 @@ news_event = {
 					limit = {
 						tag = SPC
 					}
+					# If POUM wins and Right Oppo Soviets aided them
+					if = {
+						limit = {
+							has_template = "International Marxist Brigades"
+						}
+						delete_unit_template_and_units = {
+							division_template = "International Marxist Brigades"
+							disband = yes
+						}
+					}
+					if = {
+						limit = {
+							has_template = "Soviet Special Brigades"
+						}
+						delete_unit_template_and_units = {
+							division_template = "Soviet Special Brigades"
+							disband = yes
+						}
+					}
 					every_state = {
 						limit = {
 							has_state_flag = SPR_core_of_spain_flag
@@ -721,6 +740,20 @@ news_event = {
 					}
 					country_event = { id = lar_spain.82 hours = 6 }
 				}
+			}
+			#If POUM supported by SOV and won and SOV has not won/bypasssed their civil war yet -> POUM will help SOV in their CW
+			if = {
+				limit = {
+					has_global_flag = SOV_covert_support_for_poum_flag
+					has_global_flag = SPR_poum_won
+					SOV = {
+						OR = { #Do not trigger if Soviet civil war has finished or was bypassed
+							NOT = {	has_completed_focus = SOV_coup_detat }
+							has_global_flag = SOV_soviet_civil_war
+						}
+					}
+				}
+				SOV = { country_event = { id = NSB_soviet_spanish_civil_war.6 days = 8 random_days = 4 } }
 			}
 		}
 	}

--- a/events/LAR_Spain.txt
+++ b/events/LAR_Spain.txt
@@ -2449,15 +2449,27 @@ country_event = {
 								factor = 0
 								is_historical_focus_on = yes
 							}
+							modifier = {
+								factor = 0
+								has_global_flag = SOV_covert_support_for_poum_flag #POUM UPRISING (SUPPORTED BY SOVIET RIGHT OPPOSITION)
+							}
 							complete_national_focus = SPR_regional_defense_council_of_aragon
 						}
 						10 = {
+							modifier = {
+								factor = 0
+								has_global_flag = SOV_covert_support_for_poum_flag #POUM UPRISING (SUPPORTED BY SOVIET RIGHT OPPOSITION)
+							}
 							complete_national_focus = SPR_maintain_the_second_republic
 						}
 						10 = {
 							modifier = {
 								factor = 0
 								is_historical_focus_on = yes
+							}
+							modifier = {
+								add = 10
+								has_global_flag = SOV_covert_support_for_poum_flag #POUM UPRISING (SUPPORTED BY SOVIET RIGHT OPPOSITION)
 							}
 							complete_national_focus = SPR_the_anti_fascist_workers_revolution
 						}
@@ -4785,6 +4797,10 @@ country_event = {
 					}
 				}
 			}
+			modifier = {
+				factor = 0
+				has_global_flag = SOV_covert_support_for_poum_flag #Soviet Right Opposition is providing support to the POUM
+			}
 		}
 		# Remove Spirits that will no longer be relevant
 		custom_effect_tooltip = republicans_chosen
@@ -4826,6 +4842,10 @@ country_event = {
 						option = SECOND_REPUBLIC
 					}
 				}
+			}
+			modifier = {
+				add = 30
+				has_global_flag = SOV_covert_support_for_poum_flag #Soviet Right Opposition is providing support to the POUM
 			}
 		}
 		# Remove Spirits that will no longer be relevant
@@ -4878,6 +4898,10 @@ country_event = {
 						option = STALINIST
 					}
 				}
+			}
+			modifier = {
+				factor = 0
+				has_global_flag = SOV_covert_support_for_poum_flag #Soviet Right Opposition is providing support to the POUM
 			}
 		}
 		# Remove Spirits that will no longer be relevant
@@ -6884,44 +6908,134 @@ country_event = {
 		hidden_effect = {
 			set_global_flag = SPR_anarchist_uprising_flag
 			set_global_flag = { flag = SPR_civil_war_startup value = 1 days = 3 } # Make AI avoid attacking for a few days
-			if = {
+			if = { #POUM UPRISING (SUPPORTED BY SOVIET RIGHT OPPOSITION)
 				limit = {
-					neutrality > 0.03
+					has_global_flag = SOV_covert_support_for_poum_flag
 				}
-				set_political_party = {
+				if = {
+					limit = {
+						communism > 0.03
+					}
+					set_political_party = {
+					    ideology = communism
+					    popularity = 3
+					}
+				}
+				add_popularity = {
 				    ideology = neutrality
-				    popularity = 3
+				    popularity = -0.05
+				}
+				SPC = {
+					set_rule = {
+						can_generate_female_aces = yes
+					}
+					set_politics = {
+						ruling_party = communism
+					}
+					set_popularities = {
+						communism = 58
+						democratic = 2
+						neutrality = 40
+					}
+					create_country_leader = {
+						name = "Julián Gorkin"
+						desc = "POLITICS_JULIAN_GORKIN_DESC"
+						picture = "GFX_portrait_SPR_julian_gorkin"
+						expire = "1965.1.1"
+						ideology = anarchist_communism
+						traits = {
+							militant_socialist
+						}
+					}
+					#Check for covert depots from Soviets
+					if = {
+						limit = {
+							has_global_flag = SOV_poum_has_covert_depots_from_soviets_flag
+						}
+						add_equipment_to_stockpile = {
+							type = infantry_equipment
+							amount = 6000
+							producer = SOV
+						}
+						add_equipment_to_stockpile = {
+							type = support_equipment
+							amount = 600
+							producer = SOV
+						}
+						add_equipment_to_stockpile = {
+							type = artillery_equipment
+							amount = 120
+							producer = SOV
+						}
+						add_equipment_to_stockpile = {
+							type = motorized_equipment
+							amount = 60
+							producer = SOV
+						}
+						add_equipment_to_stockpile = {
+							type = train_equipment
+							amount = 6
+							producer = SOV
+						}
+						add_opinion_modifier = {
+							target = SOV
+							modifier = SOV_sent_us_weapons
+						}
+					}
+				}
+				if = { #If Right Opposition is still under Stalin's rule, volunteers come back
+					limit = {
+						SOV = { has_completed_focus = SOV_covert_support_for_spanish_poum }
+						SPD = {
+							has_volunteers_amount_from = {
+								tag = SOV
+								count > 0
+							}
+						}
+					}
+					SOV = {	recall_volunteers_from = SPD }
 				}
 			}
-			add_popularity = {
-			    ideology = communism
-			    popularity = -0.05
-			}
-			SPC = {
-				set_rule = {
-				    can_puppet = no
-				    can_create_factions = no
-				    can_join_factions = no
-				    can_boost_own_ideology = no
-					can_generate_female_aces = yes
-					can_create_collaboration_government = no
+			else = { #REGULAR ANARCHIST UPRISING
+				if = {
+					limit = {
+						neutrality > 0.03
+					}
+					set_political_party = {
+						ideology = neutrality
+						popularity = 3
+					}
 				}
-				set_politics = {
-					ruling_party = neutrality
+				add_popularity = {
+					ideology = communism
+					popularity = -0.05
 				}
-				set_popularities = {
-					communism = 40
-					democratic = 2
-					neutrality = 58
-				}
-				create_country_leader = {
-					name = "Anarchist Commune"
-					desc = "POLITICS_ANARCHIST_COMMUNE_DESC"
-					picture = "GFX_portrait_SPR_anarchist_commune"
-					expire = "1965.1.1"
-					ideology = anarchism
-					traits = {
-						our_right_to_survive
+				SPC = {
+					set_rule = {
+						can_puppet = no
+						can_create_factions = no
+						can_join_factions = no
+						can_boost_own_ideology = no
+						can_generate_female_aces = yes
+						can_create_collaboration_government = no
+					}
+					set_politics = {
+						ruling_party = neutrality
+					}
+					set_popularities = {
+						communism = 40
+						democratic = 2
+						neutrality = 58
+					}
+					create_country_leader = {
+						name = "Anarchist Commune"
+						desc = "POLITICS_ANARCHIST_COMMUNE_DESC"
+						picture = "GFX_portrait_SPR_anarchist_commune"
+						expire = "1965.1.1"
+						ideology = anarchism
+						traits = {
+							our_right_to_survive
+						}
 					}
 				}
 			}
@@ -7083,16 +7197,35 @@ country_event = {
 			}
 			SPC = {
 				inherit_technology = SPD
-				set_politics = {
-					ruling_party = neutrality
-					last_election = "1933.4.26"
-					election_frequency = 48
-					elections_allowed = no
+				if = { #POUM UPRISING (SUPPORTED BY SOVIET RIGHT OPPOSITION)
+					limit = {
+						has_global_flag = SOV_covert_support_for_poum_flag
+					}
+					set_politics = {
+						ruling_party = communism
+						last_election = "1933.4.26"
+						election_frequency = 48
+						elections_allowed = no
+					}
+					set_popularities = {
+						neutrality = 15
+						communism = 80
+						democratic = 5
+					}
+
 				}
-				set_popularities = {
-					neutrality = 80
-					communism = 15
-					democratic = 5
+				else = { #REGULAR ANARCHIST UPRISING
+					set_politics = {
+						ruling_party = neutrality
+						last_election = "1933.4.26"
+						election_frequency = 48
+						elections_allowed = no
+					}
+					set_popularities = {
+						neutrality = 80
+						communism = 15
+						democratic = 5
+					}
 				}
 				remove_ideas = SPR_the_maximum_concession
 				add_ideas = closed_economy
@@ -7279,10 +7412,21 @@ country_event = {
 				unlock_national_focus = SPR_enlarge_the_weapon_caches
 				unlock_national_focus = SPR_distribute_arms_to_the_people
 				unlock_national_focus = SPR_disband_the_army
-				complete_national_focus = SPR_regional_defense_council_of_aragon
-				complete_national_focus = SPR_arm_the_people
-				complete_national_focus = SPR_appropriate_the_means_of_production
-				unlock_national_focus = SPR_the_maximum_concession
+				if = { #POUM UPRISING (SUPPORTED BY SOVIET RIGHT OPPOSITION)
+					limit = {
+						has_global_flag = SOV_covert_support_for_poum_flag
+					}
+					complete_national_focus = SPR_the_anti_fascist_workers_revolution
+					complete_national_focus = SPR_arm_the_workers_militias
+					complete_national_focus = SPR_demand_ministerial_positions
+					unlock_national_focus = SPR_hinder_nkvd_interference
+				}
+				else = { #REGULAR ANARCHIST UPRISING
+					complete_national_focus = SPR_regional_defense_council_of_aragon
+					complete_national_focus = SPR_arm_the_people
+					complete_national_focus = SPR_appropriate_the_means_of_production
+					unlock_national_focus = SPR_the_maximum_concession
+				}
 				unlock_national_focus = SPR_seize_the_gold_reserves
 				unlock_national_focus = SPR_masters_of_our_own_fate
 				add_timed_idea = { idea = SPR_death_before_surrender days = 900 }
@@ -7341,18 +7485,38 @@ country_event = {
 	option = {
 		name = lar_spain.9.a
 		effect_tooltip = {
-			if = {
+			if = { #POUM UPRISING (SUPPORTED BY SOVIET RIGHT OPPOSITION)
 				limit = {
-					neutrality > 0.03
+					has_global_flag = SOV_covert_support_for_poum_flag
 				}
-				set_political_party = {
+				if = {
+					limit = {
+						communism > 0.03
+					}
+					set_political_party = {
+					    ideology = communism
+					    popularity = 3
+					}
+				}
+				add_popularity = {
 				    ideology = neutrality
-				    popularity = 3
+				    popularity = -0.05
 				}
 			}
-			add_popularity = {
-			    ideology = communism
-			    popularity = -0.05
+			else = { #REGULAR ANARCHIST UPRISING
+				if = {
+					limit = {
+						neutrality > 0.03
+					}
+					set_political_party = {
+					    ideology = neutrality
+					    popularity = 3
+					}
+				}
+				add_popularity = {
+				    ideology = communism
+				    popularity = -0.05
+				}
 			}
 			add_stability = -0.1
 			transfer_units_fraction = {
@@ -7573,7 +7737,42 @@ country_event = {
 				    logistics_skill = 1
 				}
 				set_rule = { can_generate_female_aces = yes	}
-			}	
+				#Check for covert depots from Soviets
+				if = {
+					limit = {
+						has_global_flag = SOV_poum_has_covert_depots_from_soviets_flag
+					}
+					add_equipment_to_stockpile = {
+						type = infantry_equipment
+						amount = 6000
+						producer = SOV
+					}
+					add_equipment_to_stockpile = {
+						type = support_equipment
+						amount = 600
+						producer = SOV
+					}
+					add_equipment_to_stockpile = {
+						type = artillery_equipment
+						amount = 120
+						producer = SOV
+					}
+					add_equipment_to_stockpile = {
+						type = motorized_equipment
+						amount = 60
+						producer = SOV
+					}
+					add_equipment_to_stockpile = {
+						type = train_equipment
+						amount = 6
+						producer = SOV
+					}
+					add_opinion_modifier = {
+						target = SOV
+						modifier = SOV_sent_us_weapons
+					}
+				}
+			}
 			remove_ideas = SPR_the_maximum_concession
 			add_ideas = closed_economy
 			SPC = {


### PR DESCRIPTION
- [SOV] Fixed "Return Democracy to the Party" when going The Right Opposition - advisors from the Left were no longer exiled, but still imprisoned.
- [SOV] Removed Lavrenty Beriya's (NKVD Head) check for having Nikita Khrushchev as the country leader - breaks paranoia system when Stalin does the third (last possible) NKVD Head purge.
	- a different possibility is to limit the NKVD Head purge to only happen twice
- [SOV/Spain] Fixed "Covert Support for Spanish POUM" not making the POUM rise up instead of the anarchists.
	- changes in events\LAR_NewsEvents.txt and events\LAR_Spain.txt were copied from vanilla