### PR TITLE
Update countryoccupationview.gfx

### DIFF
--- a/interface/countryoccupationview.gfx
+++ b/interface/countryoccupationview.gfx
@@ -245,7 +245,7 @@ spriteTypes = {
 	spriteType = {
 		name = "GFX_occupation_policy_icon_strip"
 		textureFile = "gfx/interface/occupation/occupation_policy_icon_strip.dds"
-		noOfFrames = 12
+		noOfFrames = 13
 	}
 	
 	spriteType = {


### PR DESCRIPTION
With Blood alone extension there are 13 country occupation icons. Thus mine was offset so i changed it to 13 and all icons were shown correctly. I don't know if it could be issue without BA extension.