### PR TITLE
German civil war recoded to fix some issues

### DIFF
--- a/common/decisions/categories/SS_decision_categories.txt
+++ b/common/decisions/categories/SS_decision_categories.txt
@@ -2,6 +2,7 @@ SS_demands = {
 	icon = ger_reichskommissariats
 	allowed = {
 		original_tag = GER
+		has_character = GER_heinrich_himmler	#stops errors from civil war sides lacking the himmler character, hopefully
 	}
 
 	visible = {
@@ -12,6 +13,7 @@ SS_recruitment = {
 	icon = ger_military_buildup
 	allowed = {
 		original_tag = GER
+		has_character = GER_heinrich_himmler	#stops errors from civil war sides lacking the himmler character, hopefully
 	}
 
 	available = {
@@ -26,5 +28,6 @@ wehrmacht_demands = {
 	icon = stahlhelm
 	allowed = {
 		original_tag = GER
+		has_character = GER_heinrich_himmler	#stops errors from civil war sides lacking the himmler character, hopefully
 	}
 }

--- a/common/national_focus/r56_germany.txt
+++ b/common/national_focus/r56_germany.txt
@@ -8595,11 +8595,6 @@ focus_tree = {
 						fascism = 75
 						communism = 5
 					}
-					declare_war_on = {
-						target = GER
-						type = civil_war
-					}
-					add_civil_war_target = ROOT #does not seem to work like wiki lists
 					load_focus_tree = german_focus #seems I cant keep progress since they are a different tag, force path
 					uncomplete_national_focus = {
 						focus = GER_kill_hitler
@@ -8673,7 +8668,23 @@ focus_tree = {
 							}
 						}
 					}
-					promote_character = GER_heinrich_himmler
+					if = {
+						limit = {	#dont throw errors if none picked yet
+							OR = {
+								can_be_country_leader = GER_heinrich_himmler
+								can_be_country_leader = GER_hermann_goring
+							}
+						}
+						if = {
+							limit = {
+								has_country_flag = GER_cw_himmler_leader
+							}
+							promote_character = GER_heinrich_himmler
+							else = {
+								promote_character = GER_hermann_goring
+							}
+						}
+					}
 				}
 			}
 			country_event = r56.ger.25

--- a/common/national_focus/r56_germany.txt
+++ b/common/national_focus/r56_germany.txt
@@ -8530,9 +8530,20 @@ focus_tree = {
 		completion_reward = {
 			custom_effect_tooltip = GER_civil_war_tt
 			hidden_effect = {
+				if = {
+					limit = {
+						is_faction_leader = yes
+						NOT = {
+							any_other_country = {
+								is_in_faction_with = GER
+							}
+						}
+					}
+					dismantle_faction = yes
+				}
 				every_owned_state = { #get out of warzones
 					limit = {
-						OR = {
+						NOT = {	#simply turned OR into NOT since the non-nazi states are the exact opposite
 							state = 60
 							state = 65
 							state = 989 #East Rhineland
@@ -8552,113 +8563,51 @@ focus_tree = {
 						limit = {
 							tag = GER
 						}
-						to_state = 56 #tried array, didnt work right, this is a strategic place
+						to_state = 53
 					}
-				}
-				if = {
-					limit = {
-						is_faction_leader = yes
-						NOT = {
-							any_other_country = {
-								is_in_faction_with = GER
-							}
-						}
-					}
-					dismantle_faction = yes
 				}
 				add_popularity = {
 					ideology = fascism
-					popularity = 0.3 #these are splitting off
+					popularity = -0.3 #these are splitting off
 				}
-				create_dynamic_country = { #commies
+				create_dynamic_country = { #dynamic fascist side here, other dependent on choice, keeps player as the original tag
 					original_tag = GER
-					set_country_flag = is_commie_ger_cw
-					transfer_state = 60
-					transfer_state = 65
-					set_province_controller = 9560
-					set_province_controller = 9375
-					set_province_controller = 6218
-					set_province_controller = 6377
-					set_province_controller = 6487
-					set_province_controller = 11468
-					set_province_controller = 11402
-					set_province_controller = 11493
-					set_province_controller = 6513
-					set_province_controller = 526
-					set_province_controller = 3522
-					set_province_controller = 3526
-					set_province_controller = 6298
+					transfer_state = 5 #Ermland-Mausuren
+					transfer_state = 763 #Konighsberg
+					transfer_state = 63 #Hinterpommern
+					transfer_state = 68 #Neumark
+					transfer_state = 62 #Vorpommern
+					transfer_state = 66 #Niederschlesien
+					transfer_state = 64 #Brandenburg, slightly contested
+					transfer_state = 59 #Hannover, contested
+					transfer_state = 61 #Mecklenburg
+					transfer_state = 58 #Schleswig-holstein
+					transfer_state = 998 #north holstein
+					transfer_state = 56 #Wesserems
+					transfer_state = 57 #Westfalen
+					transfer_state = 55 #Hessen
 					set_politics = {
-						ruling_party = communism
-					}
-					add_popularity = {
-						ideology = communism
-						popularity = 0.75
-					}
-					declare_war_on = {
-						target = GER
-						type = civil_war
-					}
-					add_civil_war_target = ROOT #does not seem to work like wiki lists
-					set_capital = {state = 65} #largest communist share
-					load_focus_tree = german_focus #seems I cant keep progress since they are a different tag, force path
-					unlock_national_focus = GER_kill_hitler
-					unlock_national_focus = GER_political_turmoil
-					complete_national_focus = GER_repeal_reichstag_fire_decree
-					#do not split units yet, because player could sabotage the nazis before picking in event
-					add_ideas = {
-						extensive_conscription
-						war_economy
-					}
-					set_rule = {
-						can_send_volunteers = yes
-					}
-				}
-				create_dynamic_country = { #democrats
-					original_tag = GER
-					set_country_flag = is_democratic_ger_cw
-					transfer_state = 989 #East Rhineland
-					transfer_state = 50 
-					transfer_state = 51 #Rhineland
-					transfer_state = 52 #Bavaria
-					transfer_state = 53 #Bavaria
-					transfer_state = 54 #Bavaria
-					transfer_state = 42 #Mosselland
-					transfer_state = 922
-					transfer_state = 923 #Baden
-					transfer_state = 67 #Oppeln
-					set_politics = {
-						ruling_party = democratic
+						ruling_party = fascism
 					}
 					set_popularities = {
-						democratic = 45
-						neutrality = 25
-						fascism = 10
-						communism = 20
+						democratic = 5
+						neutrality = 15
+						fascism = 75
+						communism = 5
 					}
 					declare_war_on = {
 						target = GER
 						type = civil_war
 					}
 					add_civil_war_target = ROOT #does not seem to work like wiki lists
-					every_country = { #declare war on commie side
-						limit = {
-							original_tag = GER
-							not = {
-								tag = GER
-							}
-						}
-						declare_war_on = {
-							target = PREV
-							type = civil_war
-						}
-						add_civil_war_target = PREV #does not seem to work like wiki lists
-					}
 					load_focus_tree = german_focus #seems I cant keep progress since they are a different tag, force path
-					unlock_national_focus = GER_kill_hitler
-					unlock_national_focus = GER_political_turmoil
-					complete_national_focus = GER_restore_weimar  #no switching ideology afterwards :P
-					#do not split units yet, because player could sabotage the nazis before picking in event
+					uncomplete_national_focus = {
+						focus = GER_kill_hitler
+						uncomplete_children = yes
+						refund_political_power = no
+					}
+					complete_national_focus = GER_denounce_versailles
+					unlock_national_focus = GER_rhineland
 					add_ideas = {
 						limited_conscription
 						partial_economic_mobilisation
@@ -8666,14 +8615,66 @@ focus_tree = {
 					set_rule = {
 						can_send_volunteers = yes
 					}
+					division_template = {
+						name = "SS-Sturmbrigade"
+						is_locked = yes
+					
+						division_names_group = GER_Inf_01
+					
+						regiments = {
+							infantry = { x = 0 y = 0 }
+							infantry = { x = 0 y = 1 }
+							infantry = { x = 0 y = 2 }
+							infantry = { x = 0 y = 3 }
+						}
+						support = { 
+							engineer = { x = 0 y = 0 }
+						}
+					}
+					every_controlled_state = {
+						create_unit = {
+							division = "name = \"Infantry Division\" division_template = \"SS-Sturmbrigade\" start_experience_factor = 0.05"
+							owner = PREV
+							allow_spawning_on_enemy_provs = no
+						}
+					}
+					ROOT = {
+						every_character = { #move over nazis
+							limit = {
+								OR = {
+									is_character = GER_rudolf_hess
+									is_character = GER_martin_bormann
+									is_character = GER_joseph_goebbels
+									is_character = GER_wilhelm_keitel
+									is_character = GER_heinrich_himmler
+									is_character = GER_hermann_goring
+									is_character = GER_joachim_von_ribbentrop
+									is_character = GER_fritz_todt
+									is_character = GER_albert_speer
+									is_character = GER_werner_von_fritsch #despite the Blomberg–Fritsch affair, he seemingly didnt stop supporting anti-democratic and nazi ideals
+									is_character = GER_ferdinand_schorner
+									has_id = 10 #Walter Model
+									has_id = 15 #Walter Kruger
+									has_id = 20 #Paul Hausser
+									has_id = 24 #Sepp Dietrich
+								}
+							}
+							set_nationality = PREV.PREV
+						}
+						transfer_units_fraction= {
+							target = PREV.PREV
+							size = 0.48
+							stockpile_ratio = 0.36 #communist raiding, democratic industry
+							army_ratio = 0.51
+							navy_ratio = 0.65	   #strong control in naval regions
+							air_ratio = 0.55
+							keep_unit_leaders_trigger = {
+								always = yes 
+							}
+						}
+					}
+					promote_character = GER_heinrich_himmler
 				}
-				uncomplete_national_focus = {
-					focus = GER_kill_hitler
-					uncomplete_children = yes
-					refund_political_power = no
-				}
-				complete_national_focus = GER_denounce_versailles
-				unlock_national_focus = GER_rhineland
 			}
 			country_event = r56.ger.25
 			set_global_flag = r56_german_cw_ongoing

--- a/events/Germany.txt
+++ b/events/Germany.txt
@@ -12826,116 +12826,582 @@ country_event = { #Germany civil war
 
 	immediate = {
 		hidden_effect={
-			random_country = {
-				limit = {
-					original_tag = GER
-					NOT = {
-						tag = GER
-					}
-					has_government = communism
+			# random_country = {
+			# 	limit = {
+			# 		original_tag = GER
+			# 		NOT = {
+			# 			tag = GER
+			# 		}
+			# 		has_government = communism
+			# 	}
+			# 	save_event_target_as = communist_germany
+			# }
+			###heres your starting designs now stop annoying me about debug mode not saying your tag is GER
+		# 	every_country = {
+		# 		limit = {
+		# 			OR = {
+		# 				tag = event_target:communist_germany
+		# 				tag = event_target:conservative_germany
+		# 			}
+		# 		}
+		# 		if = {
+		# 			limit = {
+		# 				not = { has_dlc = "Man the Guns" }
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Scharnhorst Class"
+		# 				type = battle_cruiser_2
+		# 				parent_version = 0
+		# 				upgrades = {
+		# 					ship_reliability_upgrade = 3
+		# 					ship_engine_upgrade = 1
+		# 					ship_armor_upgrade = 4
+		# 					ship_gun_upgrade = 0
+		# 				}
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Deutschland Class"
+		# 				type = battleship_1
+		# 				parent_version = 0
+		# 				upgrades = {
+		# 					ship_reliability_upgrade = 0
+		# 					ship_engine_upgrade = 0
+		# 					ship_armor_upgrade = 0
+		# 					ship_gun_upgrade = 0
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Deutschland Class"
+		# 				type = heavy_cruiser_2
+		# 				parent_version = 0
+		# 				upgrades = {
+		# 					ship_reliability_upgrade = 1
+		# 					ship_engine_upgrade = 0
+		# 					ship_armor_upgrade = 0
+		# 					ship_gun_upgrade = 4
+		# 				}
+		# 				obsolete=yes
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Leipzig Class"
+		# 				type = light_cruiser_1
+		# 				parent_version = 0
+		# 				upgrades = {
+		# 					ship_reliability_upgrade = 2
+		# 					ship_engine_upgrade = 2
+		# 					ship_gun_upgrade = 3
+		# 					ship_anti_air_upgrade = 3
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 			# Light Cruisers #
+		# 			create_equipment_variant = {
+		# 				name = "Königsberg Class"
+		# 				type = light_cruiser_1
+		# 				parent_version = 0
+		# 				upgrades = {
+		# 					ship_reliability_upgrade = 2
+		# 					ship_engine_upgrade = 2
+		# 					ship_gun_upgrade = 3
+		# 					ship_anti_air_upgrade = 2
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "1924 Type"
+		# 				type = destroyer_1
+		# 				parent_version = 0
+		# 				upgrades = {
+		# 					ship_torpedo_upgrade = 1
+		# 					destroyer_engine_upgrade = 1
+		# 					ship_ASW_upgrade = 0
+		# 					ship_anti_air_upgrade = 1
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Zerstörer 1934A"
+		# 				type = destroyer_2
+		# 				parent_version = 0
+		# 				upgrades = {
+		# 					ship_torpedo_upgrade = 1
+		# 					destroyer_engine_upgrade = 1
+		# 					ship_ASW_upgrade = 1
+		# 					ship_anti_air_upgrade = 1
+		# 				}
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Type IIB"
+		# 				type = submarine_2
+		# 				parent_version = 0
+		# 				upgrades = {
+		# 					ship_reliability_upgrade = 1
+		# 					sub_engine_upgrade = 0
+		# 					sub_stealth_upgrade = 1
+		# 					sub_torpedo_upgrade = 0
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Type VIIA"
+		# 				type = submarine_2
+		# 				parent_version = 0
+		# 				upgrades = {
+		# 					ship_reliability_upgrade = 4
+		# 					sub_engine_upgrade = 3
+		# 					sub_stealth_upgrade = 2
+		# 					sub_torpedo_upgrade = 1
+		# 				}
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Type IA"
+		# 				type = submarine_1
+		# 				parent_version = 0
+		# 				upgrades = {
+		# 					ship_reliability_upgrade = 1
+		# 					sub_engine_upgrade = 2
+		# 					sub_stealth_upgrade = 2
+		# 					sub_torpedo_upgrade = 2
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 		}
+		# 		if = {
+		# 			limit = { has_dlc = "Man the Guns" }
+		# 			create_equipment_variant = { #Are we making a CV or a Monster Cruiser? Make up your mind
+		# 				name = "Graf Zeppelin Class"
+		# 				type = ship_hull_carrier_conversion_ca
+		# 				name_group = GER_CV_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_deck_slot_1 = ship_deck_space
+		# 					fixed_ship_deck_slot_2 = ship_deck_space
+		# 					fixed_ship_anti_air_slot = ship_anti_air_2
+		# 					fixed_ship_radar_slot = empty
+		# 					fixed_ship_engine_slot = cruiser_ship_engine_2
+		# 					fixed_ship_secondaries_slot = ship_secondaries_2 
+		# 				}
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Deutschland Class"
+		# 				type = ship_hull_cruiser_panzerschiff
+		# 				name_group = GER_CA_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_anti_air_slot = ship_anti_air_1
+		# 					fixed_ship_battery_slot = ship_heavy_battery_2
+		# 					fixed_ship_secondaries_slot = ship_secondaries_1
+		# 					fixed_ship_armor_slot = ship_armor_cruiser_2
+		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+		# 					fixed_ship_engine_slot = cruiser_ship_engine_2
+		# 					front_1_custom_slot = ship_anti_air_1
+		# 					mid_1_custom_slot = ship_airplane_launcher_1
+		# 					mid_2_custom_slot = ship_secondaries_1
+		# 					rear_1_custom_slot = ship_torpedo_1
+		# 				}
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Type 24 Class"
+		# 				type = ship_hull_light_1
+		# 				name_group = GER_TB_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_battery_slot = ship_light_battery_1
+		# 					fixed_ship_anti_air_slot = empty
+		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+		# 					fixed_ship_radar_slot = empty
+		# 					fixed_ship_engine_slot = light_ship_engine_1
+		# 					fixed_ship_torpedo_slot = ship_torpedo_1
+		# 					rear_1_custom_slot = ship_mine_layer_1
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Zerstörer 1934 Class"
+		# 				type = ship_hull_light_2
+		# 				name_group = GER_DD_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_battery_slot = ship_light_battery_2
+		# 					fixed_ship_anti_air_slot = ship_anti_air_1
+		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+		# 					fixed_ship_radar_slot = empty
+		# 					fixed_ship_engine_slot = light_ship_engine_2
+		# 					fixed_ship_torpedo_slot = ship_torpedo_1
+		# 					mid_1_custom_slot = ship_torpedo_1
+		# 					rear_1_custom_slot = ship_mine_layer_1
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Zerstörer 1934A Class"
+		# 				type = ship_hull_light_2
+		# 				name_group = GER_DD_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_battery_slot = ship_light_battery_2
+		# 					fixed_ship_anti_air_slot = ship_anti_air_1
+		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+		# 					fixed_ship_radar_slot = empty
+		# 					fixed_ship_engine_slot = light_ship_engine_2
+		# 					fixed_ship_torpedo_slot = ship_torpedo_1
+		# 					mid_1_custom_slot = ship_torpedo_1
+		# 					rear_1_custom_slot = ship_depth_charge_1
+		# 				}
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Type I Class"
+		# 				type = ship_hull_submarine_2
+		# 				name_group = GER_SS_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_torpedo_slot = ship_torpedo_sub_1
+		# 					fixed_ship_engine_slot = sub_ship_engine_1
+		# 					rear_1_custom_slot = empty
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Type II Class"
+		# 				type = ship_hull_submarine_1
+		# 				name_group = GER_SS_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_torpedo_slot = ship_torpedo_sub_1
+		# 					fixed_ship_engine_slot = sub_ship_engine_1
+		# 					rear_1_custom_slot = empty
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Type IX Class"
+		# 				type = ship_hull_submarine_2
+		# 				name_group = GER_SS_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_torpedo_slot = ship_torpedo_sub_2
+		# 					fixed_ship_engine_slot = sub_ship_engine_2
+		# 					rear_1_custom_slot = empty
+		# 				}
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Type VII Class"
+		# 				type = ship_hull_submarine_2
+		# 				name_group = GER_SS_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_torpedo_slot = ship_torpedo_sub_2
+		# 					fixed_ship_engine_slot = sub_ship_engine_1
+		# 					rear_1_custom_slot = empty
+		# 				}
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Königsberg Class"
+		# 				type = ship_hull_cruiser_2
+		# 				name_group = GER_CL_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_battery_slot = ship_light_medium_battery_1
+		# 					fixed_ship_anti_air_slot = ship_anti_air_1
+		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+		# 					fixed_ship_radar_slot = empty
+		# 					fixed_ship_engine_slot = cruiser_ship_engine_1
+		# 					fixed_ship_armor_slot = ship_armor_cruiser_1
+		# 					mid_1_custom_slot = ship_torpedo_1
+		# 					mid_2_custom_slot = ship_light_medium_battery_1
+		# 					rear_1_custom_slot = ship_mine_layer_1
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Emden Class"
+		# 				type = ship_hull_cruiser_1
+		# 				name_group = GER_CL_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_battery_slot = ship_light_medium_battery_1
+		# 					fixed_ship_anti_air_slot = empty
+		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+		# 					fixed_ship_radar_slot = empty
+		# 					fixed_ship_engine_slot = cruiser_ship_engine_1
+		# 					fixed_ship_armor_slot = ship_armor_cruiser_1
+		# 					mid_1_custom_slot = ship_light_medium_battery_1
+		# 					mid_2_custom_slot = ship_torpedo_1
+		# 					rear_1_custom_slot = empty
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Bremse Class"
+		# 				type = ship_hull_cruiser_1
+		# 				name_group = GER_CL_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_battery_slot = ship_light_battery_1
+		# 					fixed_ship_anti_air_slot = ship_anti_air_1
+		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+		# 					fixed_ship_radar_slot = empty
+		# 					fixed_ship_engine_slot = cruiser_ship_engine_1
+		# 					mid_1_custom_slot = ship_anti_air_1
+		# 					mid_2_custom_slot = ship_mine_layer_1
+		# 					rear_1_custom_slot = ship_mine_layer_1
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Leipzig Class"
+		# 				type = ship_hull_cruiser_2
+		# 				name_group = GER_CL_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_battery_slot = ship_light_medium_battery_1
+		# 					fixed_ship_anti_air_slot = ship_anti_air_2
+		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+		# 					fixed_ship_radar_slot = empty
+		# 					fixed_ship_engine_slot = cruiser_ship_engine_1
+		# 					fixed_ship_armor_slot = ship_armor_cruiser_1
+		# 					front_1_custom_slot = ship_light_medium_battery_1
+		# 					mid_1_custom_slot = ship_torpedo_1
+		# 					mid_2_custom_slot = ship_mine_layer_1
+		# 					rear_1_custom_slot = ship_airplane_launcher_1
+		# 				}
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Admiral Hipper Class"
+		# 				type = ship_hull_cruiser_2
+		# 				name_group = GER_CA_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_battery_slot = ship_medium_battery_2
+		# 					fixed_ship_anti_air_slot = ship_anti_air_1
+		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+		# 					fixed_ship_radar_slot = empty
+		# 					fixed_ship_engine_slot = cruiser_ship_engine_1
+		# 					fixed_ship_armor_slot = ship_armor_cruiser_2
+		# 					front_1_custom_slot = ship_anti_air_1
+		# 					mid_1_custom_slot = ship_torpedo_1
+		# 					mid_2_custom_slot = ship_airplane_launcher_1
+		# 					rear_1_custom_slot = ship_medium_battery_2
+		# 				}
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Scharnhorst Class"
+		# 				type = ship_hull_heavy_2
+		# 				name_group = GER_BB_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_battery_slot = ship_heavy_battery_2
+		# 					fixed_ship_anti_air_slot = ship_anti_air_1
+		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+		# 					fixed_ship_radar_slot = empty
+		# 					fixed_ship_engine_slot = heavy_ship_engine_2
+		# 					fixed_ship_secondaries_slot = ship_secondaries_1
+		# 					fixed_ship_armor_slot = ship_armor_bb_1
+		# 					front_1_custom_slot = ship_anti_air_1
+		# 					mid_1_custom_slot = empty
+		# 					mid_2_custom_slot = ship_secondaries_1
+		# 					rear_1_custom_slot = ship_heavy_battery_2
+		# 				}
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Deutschland Class"
+		# 				type = ship_hull_pre_dreadnought
+		# 				name_group = GER_BB_HISTORICAL
+		# 				parent_version = 0
+		# 				modules = {
+		# 					fixed_ship_battery_slot = ship_heavy_battery_1
+		# 					fixed_ship_anti_air_slot = ship_anti_air_1
+		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+		# 					fixed_ship_radar_slot = empty
+		# 					fixed_ship_engine_slot = heavy_ship_engine_1
+		# 					fixed_ship_secondaries_slot = ship_secondaries_1
+		# 					fixed_ship_armor_slot = ship_armor_bb_1
+		# 					front_1_custom_slot = ship_anti_air_1
+		# 					mid_1_custom_slot = ship_secondaries_1
+		# 					rear_1_custom_slot = ship_torpedo_1
+		# 				}
+		# 				obsolete = yes
+		# 			}
+		# 		}
+		# 		create_equipment_variant = {
+		# 			name = "Ju 86"
+		# 			type = tac_bomber_equipment_0
+		# 			upgrades = {
+		# 				plane_tac_bomb_upgrade = 5
+		# 				plane_range_upgrade = 5
+		# 				plane_engine_upgrade = 5
+		# 				plane_reliability_upgrade = 10
+		# 			}
+		# 			obsolete = yes
+		# 		}
+		# 		create_equipment_variant = {
+		# 			name = "Do 17"
+		# 			type = tac_bomber_equipment_0
+		# 			upgrades = {
+		# 				plane_tac_bomb_upgrade = 5
+		# 				plane_range_upgrade = 1
+		# 				plane_engine_upgrade = 1
+		# 				plane_reliability_upgrade = 5
+		# 			}
+		# 			obsolete = yes
+		# 		}
+		# 		if = {
+		# 			limit = {
+		# 				has_dlc = "No Step Back"
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Leichttraktor"
+		# 				type = light_tank_chassis_0
+		# 				parent_version = 0
+		# 				modules = {
+		# 					main_armament_slot = tank_small_cannon
+		# 					turret_type_slot = tank_light_two_man_tank_turret
+		# 					suspension_type_slot = tank_christie_suspension
+		# 					armor_type_slot = tank_riveted_armor
+		# 					engine_type_slot = tank_gasoline_engine
+		# 					special_type_slot_1 = tank_radio_1
+		# 				}
+		# 				upgrades = {
+		# 					tank_nsb_engine_upgrade = 2
+		# 					tank_nsb_armor_upgrade = 2
+		# 				}
+		# 				obsolete = yes
+		# 				icon = "gfx/interface/technologies/gwtank.dds"
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Panzer I Ausf. A"
+		# 				type = light_tank_chassis_1
+		# 				parent_version = 0
+		# 				modules = {
+		# 					main_armament_slot = tank_heavy_machine_gun
+		# 					turret_type_slot = tank_light_one_man_tank_turret
+		# 					suspension_type_slot = tank_christie_suspension
+		# 					armor_type_slot = tank_riveted_armor
+		# 					engine_type_slot = tank_gasoline_engine
+		# 					special_type_slot_1 = tank_radio_1
+		# 				}
+		# 				upgrades = {
+		# 					tank_nsb_engine_upgrade = 5
+		# 					tank_nsb_armor_upgrade = 1
+		# 				}
+		# 				icon = "gfx/interface/technologies/ger_basic_light_tank.dds"
+		# 				obsolete = yes
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Neubaufahrzeug"
+		# 				type = heavy_tank_chassis_1
+		# 				parent_version = 0
+		# 				modules = {
+		# 					main_armament_slot = tank_close_support_gun
+		# 					turret_type_slot = tank_heavy_three_man_tank_turret
+		# 					suspension_type_slot = tank_bogie_suspension
+		# 					armor_type_slot = tank_riveted_armor
+		# 					engine_type_slot = tank_gasoline_engine
+		# 					special_type_slot_1 = tank_radio_1
+		# 					special_type_slot_2 = secondary_turret_hmg
+		# 					special_type_slot_3 = secondary_turret_hmg
+		# 					special_type_slot_4 = secondary_turret_hmg
+		# 				}
+		# 				upgrades = {
+		# 					tank_nsb_engine_upgrade = 6
+		# 					tank_nsb_armor_upgrade = 2
+		# 				}
+		# 				icon = "gfx/interface/technologies/ger_basic_heavy_tank.dds"
+		# 			}
+		# 			create_equipment_variant = {
+		# 				name = "Panzer II Ausf. a"
+		# 				type = light_tank_chassis_2
+		# 				parent_version = 0
+		# 				modules = {
+		# 					main_armament_slot = tank_auto_cannon
+		# 					turret_type_slot = tank_light_two_man_tank_turret
+		# 					suspension_type_slot = tank_christie_suspension
+		# 					armor_type_slot = tank_riveted_armor
+		# 					engine_type_slot = tank_gasoline_engine
+		# 					special_type_slot_1 = tank_radio_1
+		# 				}
+		# 				upgrades = {
+		# 					tank_nsb_engine_upgrade = 3
+		# 					tank_nsb_armor_upgrade = 2
+		# 				}
+		# 				icon = "gfx/interface/technologies/ger_imp_light_tank.dds"
+		# 			}
+		# 		}
+		# 	}
+		}
+	}
+
+	option = { #Democrats
+		name = r56.ger.25.a
+		hidden_effect = {
+			create_dynamic_country = { #commies
+				original_tag = GER
+				set_country_flag = is_commie_ger_cw
+				transfer_state = 60
+				transfer_state = 65
+				set_province_controller = 9560
+				set_province_controller = 9375
+				set_province_controller = 6218
+				set_province_controller = 6377
+				set_province_controller = 6487
+				set_province_controller = 11468
+				set_province_controller = 11402
+				set_province_controller = 11493
+				set_province_controller = 6513
+				set_province_controller = 526
+				set_province_controller = 3522
+				set_province_controller = 3526
+				set_province_controller = 6298
+				set_politics = {
+					ruling_party = communism
 				}
-				save_event_target_as = communist_germany
-			}
-			random_country = {
-				limit = {
-					original_tag = GER
-					NOT = {
-						tag = GER
-					}
-					has_government = democratic
+				add_popularity = {
+					ideology = communism
+					popularity = 0.75
 				}
-				save_event_target_as = conservative_germany
-			}
-			every_character = {
-				limit = {
-					OR = {
-						is_character = GER_ernst_thalmann
-						is_character = GER_Walter_Ulbricht
-						is_character = GER_franz_jacob
-						is_character = GER_Franz_Dahlem
-						is_character = GER_Bernhard_Bastlein
-					}
+				declare_war_on = {
+					target = GER
+					type = civil_war
 				}
-				set_nationality = event_target:communist_germany
-			}
-			every_character = { #move over advisors and leaders
-				limit = {
-					OR = {
-						is_advisor = yes
-						is_unit_leader = yes
-						is_character = GER_konrad_adenauer
-					}
-					NOT = {
-						is_character = GER_rudolf_hess
-						is_character = GER_martin_bormann
-						is_character = GER_joseph_goebbels
-						is_character = GER_wilhelm_keitel
-						is_character = GER_heinrich_himmler
-						is_character = GER_hermann_goring
-						is_character = GER_joachim_von_ribbentrop
-						is_character = GER_fritz_todt
-						is_character = GER_albert_speer
-						is_character = GER_werner_von_fritsch #despite the Blomberg–Fritsch affair, he seemingly didnt stop supporting anti-democratic and nazi ideals
-						is_character = GER_ferdinand_schorner
-						has_id = 10 #Walter Model
-						has_id = 15 #Walter Kruger
-						has_id = 20 #Paul Hausser
-						has_id = 24 #Sepp Dietrich
-					}
+				add_civil_war_target = ROOT #does not seem to work like wiki lists
+				set_capital = {state = 65} #largest communist share
+				load_focus_tree = german_focus #seems I cant keep progress since they are a different tag, force path
+				unlock_national_focus = GER_kill_hitler
+				unlock_national_focus = GER_political_turmoil
+				complete_national_focus = GER_repeal_reichstag_fire_decree
+				add_ideas = {
+					extensive_conscription
+					war_economy
 				}
-				set_nationality = event_target:conservative_germany
-			}
-			event_target:conservative_germany = {
-				GER_erwin_von_witzleben = {
-					add_country_leader_role = {
-						promote_leader = yes
-						country_leader = {
-						  	ideology = conservatism
-						  	expire = "1942.1.1.1" #health
-						  	traits = {  }
+				set_rule = {
+					can_send_volunteers = yes
+				}
+				ROOT = {
+					transfer_units_fraction= {	#demo to commie, inverse of commies to democratic
+						target = PREV
+						size = 0.38
+						stockpile_ratio = 0.32 #raiding
+						army_ratio = 0.3
+						navy_ratio = 0.4 #no majorities in naval regions
+						air_ratio = 0.15
+						keep_unit_leaders_trigger = {
+							always = yes 
 						}
 					}
-				}
-				division_template = {
-					name = "Landsturmregiment"
-					is_locked = yes
-				
-					division_names_group = GER_Inf_01
-				
-					regiments = {
-						infantry = { x = 0 y = 0 }
-						infantry = { x = 0 y = 1 }
-						infantry = { x = 0 y = 2 }
-						infantry = { x = 0 y = 3 }
-					}
-					support = { 
-						engineer = { x = 0 y = 0 }
-					}
-				}
-				every_controlled_state = {
-					limit = {
-						OR = {
-							state = 67 #Poland enclave
-							state = 54 #East
-							state = 989 #Upper
-							state = 922 #Center
+					every_character = {
+						limit = {
+							OR = {
+								is_character = GER_ernst_thalmann
+								is_character = GER_Walter_Ulbricht
+								is_character = GER_franz_jacob
+								is_character = GER_Franz_Dahlem
+								is_character = GER_Bernhard_Bastlein
+							}
 						}
-					}
-					create_unit = {
-						division = "name = \"Infantry Division\" division_template = \"Landsturmregiment\" start_experience_factor = 0.05"
-						owner = PREV
-					}
-					create_unit = {
-						division = "name = \"Infantry Division\" division_template = \"Landsturmregiment\" start_experience_factor = 0.05"
-						owner = PREV
-					}
-					create_unit = {
-						division = "name = \"Infantry Division\" division_template = \"Landsturmregiment\" start_experience_factor = 0.05"
-						owner = PREV
+						set_nationality = PREV.PREV
 					}
 				}
-			}
-			event_target:communist_germany = {
 				add_command_power = 50
 				#Thalmann was imprisoned in the communist area, make him leader here and fire an event about him being freed if communists are chosen
 				GER_ernst_thalmann = {
@@ -13041,531 +13507,28 @@ country_event = { #Germany civil war
 					}
 				}
 			}
-			###heres your starting designs now stop annoying me about debug mode not saying your tag is GER
-			every_country = {
-				limit = {
-					OR = {
-						tag = event_target:communist_germany
-						tag = event_target:conservative_germany
-					}
-				}
-				if = {
-					limit = {
-						not = { has_dlc = "Man the Guns" }
-					}
-					create_equipment_variant = {
-						name = "Scharnhorst Class"
-						type = battle_cruiser_2
-						parent_version = 0
-						upgrades = {
-							ship_reliability_upgrade = 3
-							ship_engine_upgrade = 1
-							ship_armor_upgrade = 4
-							ship_gun_upgrade = 0
-						}
-					}
-					create_equipment_variant = {
-						name = "Deutschland Class"
-						type = battleship_1
-						parent_version = 0
-						upgrades = {
-							ship_reliability_upgrade = 0
-							ship_engine_upgrade = 0
-							ship_armor_upgrade = 0
-							ship_gun_upgrade = 0
-						}
-						obsolete = yes
-					}
-					create_equipment_variant = {
-						name = "Deutschland Class"
-						type = heavy_cruiser_2
-						parent_version = 0
-						upgrades = {
-							ship_reliability_upgrade = 1
-							ship_engine_upgrade = 0
-							ship_armor_upgrade = 0
-							ship_gun_upgrade = 4
-						}
-						obsolete=yes
-					}
-					create_equipment_variant = {
-						name = "Leipzig Class"
-						type = light_cruiser_1
-						parent_version = 0
-						upgrades = {
-							ship_reliability_upgrade = 2
-							ship_engine_upgrade = 2
-							ship_gun_upgrade = 3
-							ship_anti_air_upgrade = 3
-						}
-						obsolete = yes
-					}
-					# Light Cruisers #
-					create_equipment_variant = {
-						name = "Königsberg Class"
-						type = light_cruiser_1
-						parent_version = 0
-						upgrades = {
-							ship_reliability_upgrade = 2
-							ship_engine_upgrade = 2
-							ship_gun_upgrade = 3
-							ship_anti_air_upgrade = 2
-						}
-						obsolete = yes
-					}
-					create_equipment_variant = {
-						name = "1924 Type"
-						type = destroyer_1
-						parent_version = 0
-						upgrades = {
-							ship_torpedo_upgrade = 1
-							destroyer_engine_upgrade = 1
-							ship_ASW_upgrade = 0
-							ship_anti_air_upgrade = 1
-						}
-						obsolete = yes
-					}
-					create_equipment_variant = {
-						name = "Zerstörer 1934A"
-						type = destroyer_2
-						parent_version = 0
-						upgrades = {
-							ship_torpedo_upgrade = 1
-							destroyer_engine_upgrade = 1
-							ship_ASW_upgrade = 1
-							ship_anti_air_upgrade = 1
-						}
-					}
-					create_equipment_variant = {
-						name = "Type IIB"
-						type = submarine_2
-						parent_version = 0
-						upgrades = {
-							ship_reliability_upgrade = 1
-							sub_engine_upgrade = 0
-							sub_stealth_upgrade = 1
-							sub_torpedo_upgrade = 0
-						}
-						obsolete = yes
-					}
-					create_equipment_variant = {
-						name = "Type VIIA"
-						type = submarine_2
-						parent_version = 0
-						upgrades = {
-							ship_reliability_upgrade = 4
-							sub_engine_upgrade = 3
-							sub_stealth_upgrade = 2
-							sub_torpedo_upgrade = 1
-						}
-					}
-					create_equipment_variant = {
-						name = "Type IA"
-						type = submarine_1
-						parent_version = 0
-						upgrades = {
-							ship_reliability_upgrade = 1
-							sub_engine_upgrade = 2
-							sub_stealth_upgrade = 2
-							sub_torpedo_upgrade = 2
-						}
-						obsolete = yes
-					}
-				}
-				if = {
-					limit = { has_dlc = "Man the Guns" }
-					create_equipment_variant = { #Are we making a CV or a Monster Cruiser? Make up your mind
-						name = "Graf Zeppelin Class"
-						type = ship_hull_carrier_conversion_ca
-						name_group = GER_CV_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_deck_slot_1 = ship_deck_space
-							fixed_ship_deck_slot_2 = ship_deck_space
-							fixed_ship_anti_air_slot = ship_anti_air_2
-							fixed_ship_radar_slot = empty
-							fixed_ship_engine_slot = cruiser_ship_engine_2
-							fixed_ship_secondaries_slot = ship_secondaries_2 
-						}
-					}
-					create_equipment_variant = {
-						name = "Deutschland Class"
-						type = ship_hull_cruiser_panzerschiff
-						name_group = GER_CA_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_anti_air_slot = ship_anti_air_1
-							fixed_ship_battery_slot = ship_heavy_battery_2
-							fixed_ship_secondaries_slot = ship_secondaries_1
-							fixed_ship_armor_slot = ship_armor_cruiser_2
-							fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-							fixed_ship_engine_slot = cruiser_ship_engine_2
-							front_1_custom_slot = ship_anti_air_1
-							mid_1_custom_slot = ship_airplane_launcher_1
-							mid_2_custom_slot = ship_secondaries_1
-							rear_1_custom_slot = ship_torpedo_1
-						}
-					}
-					create_equipment_variant = {
-						name = "Type 24 Class"
-						type = ship_hull_light_1
-						name_group = GER_TB_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_battery_slot = ship_light_battery_1
-							fixed_ship_anti_air_slot = empty
-							fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-							fixed_ship_radar_slot = empty
-							fixed_ship_engine_slot = light_ship_engine_1
-							fixed_ship_torpedo_slot = ship_torpedo_1
-							rear_1_custom_slot = ship_mine_layer_1
-						}
-						obsolete = yes
-					}
-					create_equipment_variant = {
-						name = "Zerstörer 1934 Class"
-						type = ship_hull_light_2
-						name_group = GER_DD_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_battery_slot = ship_light_battery_2
-							fixed_ship_anti_air_slot = ship_anti_air_1
-							fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-							fixed_ship_radar_slot = empty
-							fixed_ship_engine_slot = light_ship_engine_2
-							fixed_ship_torpedo_slot = ship_torpedo_1
-							mid_1_custom_slot = ship_torpedo_1
-							rear_1_custom_slot = ship_mine_layer_1
-						}
-						obsolete = yes
-					}
-					create_equipment_variant = {
-						name = "Zerstörer 1934A Class"
-						type = ship_hull_light_2
-						name_group = GER_DD_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_battery_slot = ship_light_battery_2
-							fixed_ship_anti_air_slot = ship_anti_air_1
-							fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-							fixed_ship_radar_slot = empty
-							fixed_ship_engine_slot = light_ship_engine_2
-							fixed_ship_torpedo_slot = ship_torpedo_1
-							mid_1_custom_slot = ship_torpedo_1
-							rear_1_custom_slot = ship_depth_charge_1
-						}
-					}
-					create_equipment_variant = {
-						name = "Type I Class"
-						type = ship_hull_submarine_2
-						name_group = GER_SS_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_torpedo_slot = ship_torpedo_sub_1
-							fixed_ship_engine_slot = sub_ship_engine_1
-							rear_1_custom_slot = empty
-						}
-						obsolete = yes
-					}
-					create_equipment_variant = {
-						name = "Type II Class"
-						type = ship_hull_submarine_1
-						name_group = GER_SS_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_torpedo_slot = ship_torpedo_sub_1
-							fixed_ship_engine_slot = sub_ship_engine_1
-							rear_1_custom_slot = empty
-						}
-						obsolete = yes
-					}
-					create_equipment_variant = {
-						name = "Type IX Class"
-						type = ship_hull_submarine_2
-						name_group = GER_SS_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_torpedo_slot = ship_torpedo_sub_2
-							fixed_ship_engine_slot = sub_ship_engine_2
-							rear_1_custom_slot = empty
-						}
-					}
-					create_equipment_variant = {
-						name = "Type VII Class"
-						type = ship_hull_submarine_2
-						name_group = GER_SS_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_torpedo_slot = ship_torpedo_sub_2
-							fixed_ship_engine_slot = sub_ship_engine_1
-							rear_1_custom_slot = empty
-						}
-					}
-					create_equipment_variant = {
-						name = "Königsberg Class"
-						type = ship_hull_cruiser_2
-						name_group = GER_CL_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_battery_slot = ship_light_medium_battery_1
-							fixed_ship_anti_air_slot = ship_anti_air_1
-							fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-							fixed_ship_radar_slot = empty
-							fixed_ship_engine_slot = cruiser_ship_engine_1
-							fixed_ship_armor_slot = ship_armor_cruiser_1
-							mid_1_custom_slot = ship_torpedo_1
-							mid_2_custom_slot = ship_light_medium_battery_1
-							rear_1_custom_slot = ship_mine_layer_1
-						}
-						obsolete = yes
-					}
-					create_equipment_variant = {
-						name = "Emden Class"
-						type = ship_hull_cruiser_1
-						name_group = GER_CL_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_battery_slot = ship_light_medium_battery_1
-							fixed_ship_anti_air_slot = empty
-							fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-							fixed_ship_radar_slot = empty
-							fixed_ship_engine_slot = cruiser_ship_engine_1
-							fixed_ship_armor_slot = ship_armor_cruiser_1
-							mid_1_custom_slot = ship_light_medium_battery_1
-							mid_2_custom_slot = ship_torpedo_1
-							rear_1_custom_slot = empty
-						}
-						obsolete = yes
-					}
-					create_equipment_variant = {
-						name = "Bremse Class"
-						type = ship_hull_cruiser_1
-						name_group = GER_CL_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_battery_slot = ship_light_battery_1
-							fixed_ship_anti_air_slot = ship_anti_air_1
-							fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-							fixed_ship_radar_slot = empty
-							fixed_ship_engine_slot = cruiser_ship_engine_1
-							mid_1_custom_slot = ship_anti_air_1
-							mid_2_custom_slot = ship_mine_layer_1
-							rear_1_custom_slot = ship_mine_layer_1
-						}
-						obsolete = yes
-					}
-					create_equipment_variant = {
-						name = "Leipzig Class"
-						type = ship_hull_cruiser_2
-						name_group = GER_CL_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_battery_slot = ship_light_medium_battery_1
-							fixed_ship_anti_air_slot = ship_anti_air_2
-							fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-							fixed_ship_radar_slot = empty
-							fixed_ship_engine_slot = cruiser_ship_engine_1
-							fixed_ship_armor_slot = ship_armor_cruiser_1
-							front_1_custom_slot = ship_light_medium_battery_1
-							mid_1_custom_slot = ship_torpedo_1
-							mid_2_custom_slot = ship_mine_layer_1
-							rear_1_custom_slot = ship_airplane_launcher_1
-						}
-					}
-					create_equipment_variant = {
-						name = "Admiral Hipper Class"
-						type = ship_hull_cruiser_2
-						name_group = GER_CA_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_battery_slot = ship_medium_battery_2
-							fixed_ship_anti_air_slot = ship_anti_air_1
-							fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-							fixed_ship_radar_slot = empty
-							fixed_ship_engine_slot = cruiser_ship_engine_1
-							fixed_ship_armor_slot = ship_armor_cruiser_2
-							front_1_custom_slot = ship_anti_air_1
-							mid_1_custom_slot = ship_torpedo_1
-							mid_2_custom_slot = ship_airplane_launcher_1
-							rear_1_custom_slot = ship_medium_battery_2
-						}
-					}
-					create_equipment_variant = {
-						name = "Scharnhorst Class"
-						type = ship_hull_heavy_2
-						name_group = GER_BB_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_battery_slot = ship_heavy_battery_2
-							fixed_ship_anti_air_slot = ship_anti_air_1
-							fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-							fixed_ship_radar_slot = empty
-							fixed_ship_engine_slot = heavy_ship_engine_2
-							fixed_ship_secondaries_slot = ship_secondaries_1
-							fixed_ship_armor_slot = ship_armor_bb_1
-							front_1_custom_slot = ship_anti_air_1
-							mid_1_custom_slot = empty
-							mid_2_custom_slot = ship_secondaries_1
-							rear_1_custom_slot = ship_heavy_battery_2
-						}
-					}
-					create_equipment_variant = {
-						name = "Deutschland Class"
-						type = ship_hull_pre_dreadnought
-						name_group = GER_BB_HISTORICAL
-						parent_version = 0
-						modules = {
-							fixed_ship_battery_slot = ship_heavy_battery_1
-							fixed_ship_anti_air_slot = ship_anti_air_1
-							fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-							fixed_ship_radar_slot = empty
-							fixed_ship_engine_slot = heavy_ship_engine_1
-							fixed_ship_secondaries_slot = ship_secondaries_1
-							fixed_ship_armor_slot = ship_armor_bb_1
-							front_1_custom_slot = ship_anti_air_1
-							mid_1_custom_slot = ship_secondaries_1
-							rear_1_custom_slot = ship_torpedo_1
-						}
-						obsolete = yes
-					}
-				}
-				create_equipment_variant = {
-					name = "Ju 86"
-					type = tac_bomber_equipment_0
-					upgrades = {
-						plane_tac_bomb_upgrade = 5
-						plane_range_upgrade = 5
-						plane_engine_upgrade = 5
-						plane_reliability_upgrade = 10
-					}
-					obsolete = yes
-				}
-				create_equipment_variant = {
-					name = "Do 17"
-					type = tac_bomber_equipment_0
-					upgrades = {
-						plane_tac_bomb_upgrade = 5
-						plane_range_upgrade = 1
-						plane_engine_upgrade = 1
-						plane_reliability_upgrade = 5
-					}
-					obsolete = yes
-				}
-				if = {
-					limit = {
-						has_dlc = "No Step Back"
-					}
-					create_equipment_variant = {
-						name = "Leichttraktor"
-						type = light_tank_chassis_0
-						parent_version = 0
-						modules = {
-							main_armament_slot = tank_small_cannon
-							turret_type_slot = tank_light_two_man_tank_turret
-							suspension_type_slot = tank_christie_suspension
-							armor_type_slot = tank_riveted_armor
-							engine_type_slot = tank_gasoline_engine
-							special_type_slot_1 = tank_radio_1
-						}
-						upgrades = {
-							tank_nsb_engine_upgrade = 2
-							tank_nsb_armor_upgrade = 2
-						}
-						obsolete = yes
-						icon = "gfx/interface/technologies/gwtank.dds"
-					}
-					create_equipment_variant = {
-						name = "Panzer I Ausf. A"
-						type = light_tank_chassis_1
-						parent_version = 0
-						modules = {
-							main_armament_slot = tank_heavy_machine_gun
-							turret_type_slot = tank_light_one_man_tank_turret
-							suspension_type_slot = tank_christie_suspension
-							armor_type_slot = tank_riveted_armor
-							engine_type_slot = tank_gasoline_engine
-							special_type_slot_1 = tank_radio_1
-						}
-						upgrades = {
-							tank_nsb_engine_upgrade = 5
-							tank_nsb_armor_upgrade = 1
-						}
-						icon = "gfx/interface/technologies/ger_basic_light_tank.dds"
-						obsolete = yes
-					}
-					create_equipment_variant = {
-						name = "Neubaufahrzeug"
-						type = heavy_tank_chassis_1
-						parent_version = 0
-						modules = {
-							main_armament_slot = tank_close_support_gun
-							turret_type_slot = tank_heavy_three_man_tank_turret
-							suspension_type_slot = tank_bogie_suspension
-							armor_type_slot = tank_riveted_armor
-							engine_type_slot = tank_gasoline_engine
-							special_type_slot_1 = tank_radio_1
-							special_type_slot_2 = secondary_turret_hmg
-							special_type_slot_3 = secondary_turret_hmg
-							special_type_slot_4 = secondary_turret_hmg
-						}
-						upgrades = {
-							tank_nsb_engine_upgrade = 6
-							tank_nsb_armor_upgrade = 2
-						}
-						icon = "gfx/interface/technologies/ger_basic_heavy_tank.dds"
-					}
-					create_equipment_variant = {
-						name = "Panzer II Ausf. a"
-						type = light_tank_chassis_2
-						parent_version = 0
-						modules = {
-							main_armament_slot = tank_auto_cannon
-							turret_type_slot = tank_light_two_man_tank_turret
-							suspension_type_slot = tank_christie_suspension
-							armor_type_slot = tank_riveted_armor
-							engine_type_slot = tank_gasoline_engine
-							special_type_slot_1 = tank_radio_1
-						}
-						upgrades = {
-							tank_nsb_engine_upgrade = 3
-							tank_nsb_armor_upgrade = 2
-						}
-						icon = "gfx/interface/technologies/ger_imp_light_tank.dds"
+			complete_national_focus = GER_restore_weimar  #no switching ideology afterwards :P
+			set_politics = {
+				ruling_party = democratic
+			}
+			set_popularities = {
+				democratic = 45
+				neutrality = 25
+				fascism = 10
+				communism = 20
+			}
+			GER_erwin_von_witzleben = {
+				add_country_leader_role = {
+					promote_leader = yes
+					country_leader = {
+						  ideology = conservatism
+						  expire = "1942.1.1.1" #health
+						  traits = {  }
 					}
 				}
 			}
-		}
-	}
-
-	#Unit handling NEEDS to be in options or the player can disband the fascist army before switching
-	option = { #Democrats
-		name = r56.ger.25.a
-		hidden_effect = {
-			transfer_units_fraction= {
-				target = event_target:communist_germany
-				size = 0.2
-				stockpile_ratio = 0.2 #bit of raiding
-				army_ratio = 0.15
-				navy_ratio = 0.1 #no majorities in naval regions
-				air_ratio = 0.05
-				keep_unit_leaders_trigger = {
-					always = yes 
-				}
-			}
-			transfer_units_fraction= {
-				target = event_target:conservative_germany
-				size = 0.4
-				stockpile_ratio = 0.55 #industrial core
-				army_ratio = 0.4
-				navy_ratio = 0.3 #no majorities in naval regions
-				air_ratio = 0.35
-				keep_unit_leaders_trigger = {
-					always = yes 
-				}
-			}
-			#create fascist paramilitaries here, after splitting and after the player can mess with them
 			division_template = {
-				name = "SS-Sturmbrigade"
+				name = "Landsturmregiment"
 				is_locked = yes
 			
 				division_names_group = GER_Inf_01
@@ -13581,45 +13544,200 @@ country_event = { #Germany civil war
 				}
 			}
 			every_controlled_state = {
+				limit = {
+					OR = {
+						state = 67 #Poland enclave
+						state = 54 #East
+						state = 989 #Upper
+						state = 922 #Center
+					}
+				}
 				create_unit = {
-					division = "name = \"Infantry Division\" division_template = \"SS-Sturmbrigade\" start_experience_factor = 0.05"
+					division = "name = \"Infantry Division\" division_template = \"Landsturmregiment\" start_experience_factor = 0.05"
 					owner = PREV
-					allow_spawning_on_enemy_provs = no
-				}				
+				}
+				create_unit = {
+					division = "name = \"Infantry Division\" division_template = \"Landsturmregiment\" start_experience_factor = 0.05"
+					owner = PREV
+				}
+				create_unit = {
+					division = "name = \"Infantry Division\" division_template = \"Landsturmregiment\" start_experience_factor = 0.05"
+					owner = PREV
+				}
 			}
-		}
-		event_target:conservative_germany = {
-			change_tag_from = ROOT
 		}
 	}
 	option = { #Commies
 		name = r56.ger.25.b
 		hidden_effect = {
-			transfer_units_fraction= {
-				target = event_target:communist_germany
-				size = 0.2
-				stockpile_ratio = 0.2 #bit of raiding
-				army_ratio = 0.15
-				navy_ratio = 0.1 #no majorities in naval regions
-				air_ratio = 0.05
-				keep_unit_leaders_trigger = {
-					always = yes 
+			create_dynamic_country = { #democrats
+				original_tag = GER
+				set_country_flag = is_democratic_ger_cw
+				transfer_state = 989 #East Rhineland
+				transfer_state = 50 
+				transfer_state = 51 #Rhineland
+				transfer_state = 52 #Bavaria
+				transfer_state = 53 #Bavaria
+				transfer_state = 54 #Bavaria
+				transfer_state = 42 #Mosselland
+				transfer_state = 922
+				transfer_state = 923 #Baden
+				transfer_state = 67 #Oppeln
+				set_politics = {
+					ruling_party = democratic
+				}
+				set_popularities = {
+					democratic = 45
+					neutrality = 25
+					fascism = 10
+					communism = 20
+				}
+				declare_war_on = {
+					target = GER
+					type = civil_war
+				}
+				add_civil_war_target = ROOT #does not seem to work like wiki lists
+				every_country = { #declare war on the fascist side
+					limit = {
+						original_tag = GER
+						not = {
+							tag = GER
+						}
+					}
+					declare_war_on = {
+						target = PREV
+						type = civil_war
+					}
+					add_civil_war_target = PREV #does not seem to work like wiki lists
+				}
+				load_focus_tree = german_focus #seems I cant keep progress since they are a different tag, force path
+				unlock_national_focus = GER_kill_hitler
+				unlock_national_focus = GER_political_turmoil
+				complete_national_focus = GER_restore_weimar  #no switching ideology afterwards :P
+				#do not split units yet, because player could sabotage the nazis before picking in event
+				add_ideas = {
+					limited_conscription
+					partial_economic_mobilisation
+				}
+				set_rule = {
+					can_send_volunteers = yes
+				}
+				division_template = {
+					name = "Landsturmregiment"
+					is_locked = yes
+				
+					division_names_group = GER_Inf_01
+				
+					regiments = {
+						infantry = { x = 0 y = 0 }
+						infantry = { x = 0 y = 1 }
+						infantry = { x = 0 y = 2 }
+						infantry = { x = 0 y = 3 }
+					}
+					support = { 
+						engineer = { x = 0 y = 0 }
+					}
+				}
+				every_controlled_state = {
+					limit = {
+						OR = {
+							state = 67 #Poland enclave
+							state = 54 #East
+							state = 989 #Upper
+							state = 922 #Center
+						}
+					}
+					create_unit = {
+						division = "name = \"Infantry Division\" division_template = \"Landsturmregiment\" start_experience_factor = 0.05"
+						owner = PREV
+					}
+					create_unit = {
+						division = "name = \"Infantry Division\" division_template = \"Landsturmregiment\" start_experience_factor = 0.05"
+						owner = PREV
+					}
+					create_unit = {
+						division = "name = \"Infantry Division\" division_template = \"Landsturmregiment\" start_experience_factor = 0.05"
+						owner = PREV
+					}
+				}
+				ROOT = {
+					transfer_units_fraction= {	#commies to democratic, inverse of demo to commie
+						target = PREV
+						size = 0.62
+						stockpile_ratio = 0.68 #industrial core
+						army_ratio = 0.7
+						navy_ratio = 0.6 #no majorities in naval regions
+						air_ratio = 0.85
+						keep_unit_leaders_trigger = {
+							always = yes 
+						}
+					}
+					every_character = {
+						limit = {
+							NOT = {
+								is_character = GER_ernst_thalmann
+								is_character = GER_Walter_Ulbricht
+								is_character = GER_franz_jacob
+								is_character = GER_Franz_Dahlem
+								is_character = GER_Bernhard_Bastlein
+							}
+						}
+						set_nationality = PREV.PREV
+					}
+				}
+				GER_erwin_von_witzleben = {
+					add_country_leader_role = {
+						promote_leader = yes
+						country_leader = {
+						  	ideology = conservatism
+						  	expire = "1942.1.1.1" #health
+						  	traits = {  }
+						}
+					}
 				}
 			}
-			transfer_units_fraction= {
-				target = event_target:conservative_germany
-				size = 0.4
-				stockpile_ratio = 0.55 #industrial core
-				army_ratio = 0.4
-				navy_ratio = 0.3 #no majorities in naval regions
-				air_ratio = 0.35
-				keep_unit_leaders_trigger = {
-					always = yes 
+			set_province_controller = 9560
+			set_province_controller = 9375
+			set_province_controller = 6218
+			set_province_controller = 6377
+			set_province_controller = 6487
+			set_province_controller = 11468
+			set_province_controller = 11402
+			set_province_controller = 11493
+			set_province_controller = 6513
+			set_province_controller = 526
+			set_province_controller = 3522
+			set_province_controller = 3526
+			set_province_controller = 6298
+			set_politics = {
+				ruling_party = communism
+			}
+			add_popularity = {
+				ideology = communism
+				popularity = 0.75
+			}
+			add_command_power = 50
+			#Thalmann was imprisoned in the communist area, make him leader here and fire an event about him being freed if communists are chosen
+			GER_ernst_thalmann = {
+				promote_character = yes
+				promote_character = stalinism
+				set_portraits = { #temporarily doesnt use his fancy uniform
+					civilian = {
+						large="gfx/leaders/GER/r56_portrait_Ernst_Thalmann.dds"
+					}
 				}
 			}
-			#create fascist paramilitaries here, after splitting and after the player can mess with them
+			set_variable = {
+				var = GER_commie_soviet_influence
+				value = 0
+			}
+			add_equipment_to_stockpile = { #buff to compensate for lack of industry, 5-divisions worth
+				type = infantry_equipment
+				amount = 5000
+				producer = GER
+			}
 			division_template = {
-				name = "SS-Sturmbrigade"
+				name = "Rotesregiment"
 				is_locked = yes
 			
 				division_names_group = GER_Inf_01
@@ -13634,16 +13752,79 @@ country_event = { #Germany civil war
 					engineer = { x = 0 y = 0 }
 				}
 			}
-			every_controlled_state = {
+			every_controlled_state = { #16 weak units in stronghold
+				limit = {
+					OR = {
+						state = 60
+						state = 65
+					}
+				}
 				create_unit = {
-					division = "name = \"Infantry Division\" division_template = \"SS-Sturmbrigade\" start_experience_factor = 0.05"
+					division = "name = \"Infantry Division\" division_template = \"Rotesregiment\" start_experience_factor = 0.05"
+					owner = PREV
+				}
+				create_unit = {
+					division = "name = \"Infantry Division\" division_template = \"Rotesregiment\" start_experience_factor = 0.05"
+					owner = PREV
+				}
+				create_unit = {
+					division = "name = \"Infantry Division\" division_template = \"Rotesregiment\" start_experience_factor = 0.05"
+					owner = PREV
+				}
+				create_unit = {
+					division = "name = \"Infantry Division\" division_template = \"Rotesregiment\" start_experience_factor = 0.05"
+					owner = PREV
+				}
+				create_unit = {
+					division = "name = \"Infantry Division\" division_template = \"Rotesregiment\" start_experience_factor = 0.05"
+					owner = PREV
+				}
+				create_unit = {
+					division = "name = \"Infantry Division\" division_template = \"Rotesregiment\" start_experience_factor = 0.05"
+					owner = PREV
+				}
+				create_unit = {
+					division = "name = \"Infantry Division\" division_template = \"Rotesregiment\" start_experience_factor = 0.05"
+					owner = PREV
+				}
+				create_unit = {
+					division = "name = \"Infantry Division\" division_template = \"Rotesregiment\" start_experience_factor = 0.05"
+					owner = PREV
+				}
+			}
+			every_state = { #8 divisions in contested areas
+				limit = {
+					OR = {
+						state = 59
+						state = 64
+					}
+				}
+				create_unit = {
+					division = "name = \"Hamburger Rotes Regiment\" division_template = \"Rotesregiment\" start_experience_factor = 0.05"
+					owner = PREV
+					allow_spawning_on_enemy_provs = no
+				}
+				create_unit = {
+					division = "name = \"Infantry Division\" division_template = \"Rotesregiment\" start_experience_factor = 0.05"
+					owner = PREV
+					allow_spawning_on_enemy_provs = no
+				}
+				create_unit = {
+					division = "name = \"Infantry Division\" division_template = \"Rotesregiment\" start_experience_factor = 0.05"
+					owner = PREV
+					allow_spawning_on_enemy_provs = no
+				}
+				create_unit = {
+					division = "name = \"Infantry Division\" division_template = \"Rotesregiment\" start_experience_factor = 0.05"
 					owner = PREV
 					allow_spawning_on_enemy_provs = no
 				}
 			}
-		}
-		event_target:communist_germany = {
-			change_tag_from = ROOT
+			complete_national_focus = GER_repeal_reichstag_fire_decree
+			add_ideas = {
+				extensive_conscription
+				war_economy
+			}
 		}
 		custom_effect_tooltip = GER_communists_are_pretty_hard_tt
 	}

--- a/events/Germany.txt
+++ b/events/Germany.txt
@@ -4533,6 +4533,7 @@ country_event = {
 				}
 			}
 		}
+		set_country_flag = GER_cw_himmler_leader	#saves leader for civil war uprising, goring doesnt need an additional one since hes the only other option
 		hidden_effect = {
 			random_list = {
 				38 = { news_event = { hours = 4 id = r56.kill_hitler.1 } }
@@ -4560,7 +4561,7 @@ country_event = {
 					traits = {famous_aviator}
 				}
 			}
-		}		
+		}
 		hidden_effect = {
 			random_list = {
 				38 = { news_event = { hours = 4 id = r56.kill_hitler.1 } }
@@ -12824,514 +12825,6 @@ country_event = { #Germany civil war
 
 	timeout_days = 3
 
-	immediate = {
-		hidden_effect={
-			# random_country = {
-			# 	limit = {
-			# 		original_tag = GER
-			# 		NOT = {
-			# 			tag = GER
-			# 		}
-			# 		has_government = communism
-			# 	}
-			# 	save_event_target_as = communist_germany
-			# }
-			###heres your starting designs now stop annoying me about debug mode not saying your tag is GER
-		# 	every_country = {
-		# 		limit = {
-		# 			OR = {
-		# 				tag = event_target:communist_germany
-		# 				tag = event_target:conservative_germany
-		# 			}
-		# 		}
-		# 		if = {
-		# 			limit = {
-		# 				not = { has_dlc = "Man the Guns" }
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Scharnhorst Class"
-		# 				type = battle_cruiser_2
-		# 				parent_version = 0
-		# 				upgrades = {
-		# 					ship_reliability_upgrade = 3
-		# 					ship_engine_upgrade = 1
-		# 					ship_armor_upgrade = 4
-		# 					ship_gun_upgrade = 0
-		# 				}
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Deutschland Class"
-		# 				type = battleship_1
-		# 				parent_version = 0
-		# 				upgrades = {
-		# 					ship_reliability_upgrade = 0
-		# 					ship_engine_upgrade = 0
-		# 					ship_armor_upgrade = 0
-		# 					ship_gun_upgrade = 0
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Deutschland Class"
-		# 				type = heavy_cruiser_2
-		# 				parent_version = 0
-		# 				upgrades = {
-		# 					ship_reliability_upgrade = 1
-		# 					ship_engine_upgrade = 0
-		# 					ship_armor_upgrade = 0
-		# 					ship_gun_upgrade = 4
-		# 				}
-		# 				obsolete=yes
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Leipzig Class"
-		# 				type = light_cruiser_1
-		# 				parent_version = 0
-		# 				upgrades = {
-		# 					ship_reliability_upgrade = 2
-		# 					ship_engine_upgrade = 2
-		# 					ship_gun_upgrade = 3
-		# 					ship_anti_air_upgrade = 3
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 			# Light Cruisers #
-		# 			create_equipment_variant = {
-		# 				name = "Königsberg Class"
-		# 				type = light_cruiser_1
-		# 				parent_version = 0
-		# 				upgrades = {
-		# 					ship_reliability_upgrade = 2
-		# 					ship_engine_upgrade = 2
-		# 					ship_gun_upgrade = 3
-		# 					ship_anti_air_upgrade = 2
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "1924 Type"
-		# 				type = destroyer_1
-		# 				parent_version = 0
-		# 				upgrades = {
-		# 					ship_torpedo_upgrade = 1
-		# 					destroyer_engine_upgrade = 1
-		# 					ship_ASW_upgrade = 0
-		# 					ship_anti_air_upgrade = 1
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Zerstörer 1934A"
-		# 				type = destroyer_2
-		# 				parent_version = 0
-		# 				upgrades = {
-		# 					ship_torpedo_upgrade = 1
-		# 					destroyer_engine_upgrade = 1
-		# 					ship_ASW_upgrade = 1
-		# 					ship_anti_air_upgrade = 1
-		# 				}
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Type IIB"
-		# 				type = submarine_2
-		# 				parent_version = 0
-		# 				upgrades = {
-		# 					ship_reliability_upgrade = 1
-		# 					sub_engine_upgrade = 0
-		# 					sub_stealth_upgrade = 1
-		# 					sub_torpedo_upgrade = 0
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Type VIIA"
-		# 				type = submarine_2
-		# 				parent_version = 0
-		# 				upgrades = {
-		# 					ship_reliability_upgrade = 4
-		# 					sub_engine_upgrade = 3
-		# 					sub_stealth_upgrade = 2
-		# 					sub_torpedo_upgrade = 1
-		# 				}
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Type IA"
-		# 				type = submarine_1
-		# 				parent_version = 0
-		# 				upgrades = {
-		# 					ship_reliability_upgrade = 1
-		# 					sub_engine_upgrade = 2
-		# 					sub_stealth_upgrade = 2
-		# 					sub_torpedo_upgrade = 2
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 		}
-		# 		if = {
-		# 			limit = { has_dlc = "Man the Guns" }
-		# 			create_equipment_variant = { #Are we making a CV or a Monster Cruiser? Make up your mind
-		# 				name = "Graf Zeppelin Class"
-		# 				type = ship_hull_carrier_conversion_ca
-		# 				name_group = GER_CV_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_deck_slot_1 = ship_deck_space
-		# 					fixed_ship_deck_slot_2 = ship_deck_space
-		# 					fixed_ship_anti_air_slot = ship_anti_air_2
-		# 					fixed_ship_radar_slot = empty
-		# 					fixed_ship_engine_slot = cruiser_ship_engine_2
-		# 					fixed_ship_secondaries_slot = ship_secondaries_2 
-		# 				}
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Deutschland Class"
-		# 				type = ship_hull_cruiser_panzerschiff
-		# 				name_group = GER_CA_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_anti_air_slot = ship_anti_air_1
-		# 					fixed_ship_battery_slot = ship_heavy_battery_2
-		# 					fixed_ship_secondaries_slot = ship_secondaries_1
-		# 					fixed_ship_armor_slot = ship_armor_cruiser_2
-		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-		# 					fixed_ship_engine_slot = cruiser_ship_engine_2
-		# 					front_1_custom_slot = ship_anti_air_1
-		# 					mid_1_custom_slot = ship_airplane_launcher_1
-		# 					mid_2_custom_slot = ship_secondaries_1
-		# 					rear_1_custom_slot = ship_torpedo_1
-		# 				}
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Type 24 Class"
-		# 				type = ship_hull_light_1
-		# 				name_group = GER_TB_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_battery_slot = ship_light_battery_1
-		# 					fixed_ship_anti_air_slot = empty
-		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-		# 					fixed_ship_radar_slot = empty
-		# 					fixed_ship_engine_slot = light_ship_engine_1
-		# 					fixed_ship_torpedo_slot = ship_torpedo_1
-		# 					rear_1_custom_slot = ship_mine_layer_1
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Zerstörer 1934 Class"
-		# 				type = ship_hull_light_2
-		# 				name_group = GER_DD_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_battery_slot = ship_light_battery_2
-		# 					fixed_ship_anti_air_slot = ship_anti_air_1
-		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-		# 					fixed_ship_radar_slot = empty
-		# 					fixed_ship_engine_slot = light_ship_engine_2
-		# 					fixed_ship_torpedo_slot = ship_torpedo_1
-		# 					mid_1_custom_slot = ship_torpedo_1
-		# 					rear_1_custom_slot = ship_mine_layer_1
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Zerstörer 1934A Class"
-		# 				type = ship_hull_light_2
-		# 				name_group = GER_DD_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_battery_slot = ship_light_battery_2
-		# 					fixed_ship_anti_air_slot = ship_anti_air_1
-		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-		# 					fixed_ship_radar_slot = empty
-		# 					fixed_ship_engine_slot = light_ship_engine_2
-		# 					fixed_ship_torpedo_slot = ship_torpedo_1
-		# 					mid_1_custom_slot = ship_torpedo_1
-		# 					rear_1_custom_slot = ship_depth_charge_1
-		# 				}
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Type I Class"
-		# 				type = ship_hull_submarine_2
-		# 				name_group = GER_SS_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_torpedo_slot = ship_torpedo_sub_1
-		# 					fixed_ship_engine_slot = sub_ship_engine_1
-		# 					rear_1_custom_slot = empty
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Type II Class"
-		# 				type = ship_hull_submarine_1
-		# 				name_group = GER_SS_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_torpedo_slot = ship_torpedo_sub_1
-		# 					fixed_ship_engine_slot = sub_ship_engine_1
-		# 					rear_1_custom_slot = empty
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Type IX Class"
-		# 				type = ship_hull_submarine_2
-		# 				name_group = GER_SS_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_torpedo_slot = ship_torpedo_sub_2
-		# 					fixed_ship_engine_slot = sub_ship_engine_2
-		# 					rear_1_custom_slot = empty
-		# 				}
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Type VII Class"
-		# 				type = ship_hull_submarine_2
-		# 				name_group = GER_SS_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_torpedo_slot = ship_torpedo_sub_2
-		# 					fixed_ship_engine_slot = sub_ship_engine_1
-		# 					rear_1_custom_slot = empty
-		# 				}
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Königsberg Class"
-		# 				type = ship_hull_cruiser_2
-		# 				name_group = GER_CL_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_battery_slot = ship_light_medium_battery_1
-		# 					fixed_ship_anti_air_slot = ship_anti_air_1
-		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-		# 					fixed_ship_radar_slot = empty
-		# 					fixed_ship_engine_slot = cruiser_ship_engine_1
-		# 					fixed_ship_armor_slot = ship_armor_cruiser_1
-		# 					mid_1_custom_slot = ship_torpedo_1
-		# 					mid_2_custom_slot = ship_light_medium_battery_1
-		# 					rear_1_custom_slot = ship_mine_layer_1
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Emden Class"
-		# 				type = ship_hull_cruiser_1
-		# 				name_group = GER_CL_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_battery_slot = ship_light_medium_battery_1
-		# 					fixed_ship_anti_air_slot = empty
-		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-		# 					fixed_ship_radar_slot = empty
-		# 					fixed_ship_engine_slot = cruiser_ship_engine_1
-		# 					fixed_ship_armor_slot = ship_armor_cruiser_1
-		# 					mid_1_custom_slot = ship_light_medium_battery_1
-		# 					mid_2_custom_slot = ship_torpedo_1
-		# 					rear_1_custom_slot = empty
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Bremse Class"
-		# 				type = ship_hull_cruiser_1
-		# 				name_group = GER_CL_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_battery_slot = ship_light_battery_1
-		# 					fixed_ship_anti_air_slot = ship_anti_air_1
-		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-		# 					fixed_ship_radar_slot = empty
-		# 					fixed_ship_engine_slot = cruiser_ship_engine_1
-		# 					mid_1_custom_slot = ship_anti_air_1
-		# 					mid_2_custom_slot = ship_mine_layer_1
-		# 					rear_1_custom_slot = ship_mine_layer_1
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Leipzig Class"
-		# 				type = ship_hull_cruiser_2
-		# 				name_group = GER_CL_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_battery_slot = ship_light_medium_battery_1
-		# 					fixed_ship_anti_air_slot = ship_anti_air_2
-		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-		# 					fixed_ship_radar_slot = empty
-		# 					fixed_ship_engine_slot = cruiser_ship_engine_1
-		# 					fixed_ship_armor_slot = ship_armor_cruiser_1
-		# 					front_1_custom_slot = ship_light_medium_battery_1
-		# 					mid_1_custom_slot = ship_torpedo_1
-		# 					mid_2_custom_slot = ship_mine_layer_1
-		# 					rear_1_custom_slot = ship_airplane_launcher_1
-		# 				}
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Admiral Hipper Class"
-		# 				type = ship_hull_cruiser_2
-		# 				name_group = GER_CA_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_battery_slot = ship_medium_battery_2
-		# 					fixed_ship_anti_air_slot = ship_anti_air_1
-		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-		# 					fixed_ship_radar_slot = empty
-		# 					fixed_ship_engine_slot = cruiser_ship_engine_1
-		# 					fixed_ship_armor_slot = ship_armor_cruiser_2
-		# 					front_1_custom_slot = ship_anti_air_1
-		# 					mid_1_custom_slot = ship_torpedo_1
-		# 					mid_2_custom_slot = ship_airplane_launcher_1
-		# 					rear_1_custom_slot = ship_medium_battery_2
-		# 				}
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Scharnhorst Class"
-		# 				type = ship_hull_heavy_2
-		# 				name_group = GER_BB_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_battery_slot = ship_heavy_battery_2
-		# 					fixed_ship_anti_air_slot = ship_anti_air_1
-		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-		# 					fixed_ship_radar_slot = empty
-		# 					fixed_ship_engine_slot = heavy_ship_engine_2
-		# 					fixed_ship_secondaries_slot = ship_secondaries_1
-		# 					fixed_ship_armor_slot = ship_armor_bb_1
-		# 					front_1_custom_slot = ship_anti_air_1
-		# 					mid_1_custom_slot = empty
-		# 					mid_2_custom_slot = ship_secondaries_1
-		# 					rear_1_custom_slot = ship_heavy_battery_2
-		# 				}
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Deutschland Class"
-		# 				type = ship_hull_pre_dreadnought
-		# 				name_group = GER_BB_HISTORICAL
-		# 				parent_version = 0
-		# 				modules = {
-		# 					fixed_ship_battery_slot = ship_heavy_battery_1
-		# 					fixed_ship_anti_air_slot = ship_anti_air_1
-		# 					fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-		# 					fixed_ship_radar_slot = empty
-		# 					fixed_ship_engine_slot = heavy_ship_engine_1
-		# 					fixed_ship_secondaries_slot = ship_secondaries_1
-		# 					fixed_ship_armor_slot = ship_armor_bb_1
-		# 					front_1_custom_slot = ship_anti_air_1
-		# 					mid_1_custom_slot = ship_secondaries_1
-		# 					rear_1_custom_slot = ship_torpedo_1
-		# 				}
-		# 				obsolete = yes
-		# 			}
-		# 		}
-		# 		create_equipment_variant = {
-		# 			name = "Ju 86"
-		# 			type = tac_bomber_equipment_0
-		# 			upgrades = {
-		# 				plane_tac_bomb_upgrade = 5
-		# 				plane_range_upgrade = 5
-		# 				plane_engine_upgrade = 5
-		# 				plane_reliability_upgrade = 10
-		# 			}
-		# 			obsolete = yes
-		# 		}
-		# 		create_equipment_variant = {
-		# 			name = "Do 17"
-		# 			type = tac_bomber_equipment_0
-		# 			upgrades = {
-		# 				plane_tac_bomb_upgrade = 5
-		# 				plane_range_upgrade = 1
-		# 				plane_engine_upgrade = 1
-		# 				plane_reliability_upgrade = 5
-		# 			}
-		# 			obsolete = yes
-		# 		}
-		# 		if = {
-		# 			limit = {
-		# 				has_dlc = "No Step Back"
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Leichttraktor"
-		# 				type = light_tank_chassis_0
-		# 				parent_version = 0
-		# 				modules = {
-		# 					main_armament_slot = tank_small_cannon
-		# 					turret_type_slot = tank_light_two_man_tank_turret
-		# 					suspension_type_slot = tank_christie_suspension
-		# 					armor_type_slot = tank_riveted_armor
-		# 					engine_type_slot = tank_gasoline_engine
-		# 					special_type_slot_1 = tank_radio_1
-		# 				}
-		# 				upgrades = {
-		# 					tank_nsb_engine_upgrade = 2
-		# 					tank_nsb_armor_upgrade = 2
-		# 				}
-		# 				obsolete = yes
-		# 				icon = "gfx/interface/technologies/gwtank.dds"
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Panzer I Ausf. A"
-		# 				type = light_tank_chassis_1
-		# 				parent_version = 0
-		# 				modules = {
-		# 					main_armament_slot = tank_heavy_machine_gun
-		# 					turret_type_slot = tank_light_one_man_tank_turret
-		# 					suspension_type_slot = tank_christie_suspension
-		# 					armor_type_slot = tank_riveted_armor
-		# 					engine_type_slot = tank_gasoline_engine
-		# 					special_type_slot_1 = tank_radio_1
-		# 				}
-		# 				upgrades = {
-		# 					tank_nsb_engine_upgrade = 5
-		# 					tank_nsb_armor_upgrade = 1
-		# 				}
-		# 				icon = "gfx/interface/technologies/ger_basic_light_tank.dds"
-		# 				obsolete = yes
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Neubaufahrzeug"
-		# 				type = heavy_tank_chassis_1
-		# 				parent_version = 0
-		# 				modules = {
-		# 					main_armament_slot = tank_close_support_gun
-		# 					turret_type_slot = tank_heavy_three_man_tank_turret
-		# 					suspension_type_slot = tank_bogie_suspension
-		# 					armor_type_slot = tank_riveted_armor
-		# 					engine_type_slot = tank_gasoline_engine
-		# 					special_type_slot_1 = tank_radio_1
-		# 					special_type_slot_2 = secondary_turret_hmg
-		# 					special_type_slot_3 = secondary_turret_hmg
-		# 					special_type_slot_4 = secondary_turret_hmg
-		# 				}
-		# 				upgrades = {
-		# 					tank_nsb_engine_upgrade = 6
-		# 					tank_nsb_armor_upgrade = 2
-		# 				}
-		# 				icon = "gfx/interface/technologies/ger_basic_heavy_tank.dds"
-		# 			}
-		# 			create_equipment_variant = {
-		# 				name = "Panzer II Ausf. a"
-		# 				type = light_tank_chassis_2
-		# 				parent_version = 0
-		# 				modules = {
-		# 					main_armament_slot = tank_auto_cannon
-		# 					turret_type_slot = tank_light_two_man_tank_turret
-		# 					suspension_type_slot = tank_christie_suspension
-		# 					armor_type_slot = tank_riveted_armor
-		# 					engine_type_slot = tank_gasoline_engine
-		# 					special_type_slot_1 = tank_radio_1
-		# 				}
-		# 				upgrades = {
-		# 					tank_nsb_engine_upgrade = 3
-		# 					tank_nsb_armor_upgrade = 2
-		# 				}
-		# 				icon = "gfx/interface/technologies/ger_imp_light_tank.dds"
-		# 			}
-		# 		}
-		# 	}
-		}
-	}
-
 	option = { #Democrats
 		name = r56.ger.25.a
 		hidden_effect = {
@@ -13360,11 +12853,6 @@ country_event = { #Germany civil war
 					ideology = communism
 					popularity = 0.75
 				}
-				declare_war_on = {
-					target = GER
-					type = civil_war
-				}
-				add_civil_war_target = ROOT #does not seem to work like wiki lists
 				set_capital = {state = 65} #largest communist share
 				load_focus_tree = german_focus #seems I cant keep progress since they are a different tag, force path
 				unlock_national_focus = GER_kill_hitler
@@ -13400,6 +12888,14 @@ country_event = { #Germany civil war
 							}
 						}
 						set_nationality = PREV.PREV
+					}
+				}
+				every_state = { #get out of warzones, do after dividing divisions with the democrats
+					teleport_armies = {
+						limit = {
+							tag = THIS
+						}
+						to_state = 65
 					}
 				}
 				add_command_power = 50
@@ -13565,11 +13061,20 @@ country_event = { #Germany civil war
 					owner = PREV
 				}
 			}
+			country_event = ger.civil_war.3 #add designs to the newly created sides so theyll be less useless
 		}
 	}
 	option = { #Commies
 		name = r56.ger.25.b
 		hidden_effect = {
+			every_state = { #get out of warzones, do after dividing divisions with the democrats
+			teleport_armies = {
+					limit = {
+						tag = THIS
+					}
+					to_state = 60
+				}
+			}
 			create_dynamic_country = { #democrats
 				original_tag = GER
 				set_country_flag = is_democratic_ger_cw
@@ -13591,24 +13096,6 @@ country_event = { #Germany civil war
 					neutrality = 25
 					fascism = 10
 					communism = 20
-				}
-				declare_war_on = {
-					target = GER
-					type = civil_war
-				}
-				add_civil_war_target = ROOT #does not seem to work like wiki lists
-				every_country = { #declare war on the fascist side
-					limit = {
-						original_tag = GER
-						not = {
-							tag = GER
-						}
-					}
-					declare_war_on = {
-						target = PREV
-						type = civil_war
-					}
-					add_civil_war_target = PREV #does not seem to work like wiki lists
 				}
 				load_focus_tree = german_focus #seems I cant keep progress since they are a different tag, force path
 				unlock_national_focus = GER_kill_hitler
@@ -13683,6 +13170,14 @@ country_event = { #Germany civil war
 							}
 						}
 						set_nationality = PREV.PREV
+					}
+				}
+				every_state = { #get out of warzones, do after dividing divisions with the democrats
+					teleport_armies = {
+						limit = {
+							tag = THIS
+						}
+						to_state = 42
 					}
 				}
 				GER_erwin_von_witzleben = {
@@ -13825,6 +13320,7 @@ country_event = { #Germany civil war
 				extensive_conscription
 				war_economy
 			}
+			country_event = ger.civil_war.3 #add designs to the newly created sides so theyll be less useless
 		}
 		custom_effect_tooltip = GER_communists_are_pretty_hard_tt
 	}
@@ -14194,6 +13690,522 @@ country_event = { #Commie German
 		name = ger.civil_war.2.b
 		ai_chance = { 
 			factor = 1
+		}
+	}
+}
+
+
+country_event = {
+	id = ger.civil_war.3
+
+	is_triggered_only = yes
+
+	hidden = yes
+
+	immediate = {
+		every_country = {	#this means ROOT cant be used
+			limit = {
+				original_tag = GER
+				NOT = {
+					tag = GER
+				}
+			}
+			every_other_country = {
+				limit = {
+					original_tag = GER
+				}
+				PREV = {				#every AI Germany side
+					declare_war_on = {
+						target = PREV	#every other Germany side
+						type = civil_war
+					}
+					add_civil_war_target = PREV
+				}
+			}
+			if = {
+				limit = {
+					not = { has_dlc = "Man the Guns" }
+				}
+				create_equipment_variant = {
+					name = "Scharnhorst Class"
+					type = battle_cruiser_2
+					parent_version = 0
+					upgrades = {
+						ship_reliability_upgrade = 3
+						ship_engine_upgrade = 1
+						ship_armor_upgrade = 4
+						ship_gun_upgrade = 0
+					}
+				}
+				create_equipment_variant = {
+					name = "Deutschland Class"
+					type = battleship_1
+					parent_version = 0
+					upgrades = {
+						ship_reliability_upgrade = 0
+						ship_engine_upgrade = 0
+						ship_armor_upgrade = 0
+						ship_gun_upgrade = 0
+					}
+					obsolete = yes
+				}
+				create_equipment_variant = {
+					name = "Deutschland Class"
+					type = heavy_cruiser_2
+					parent_version = 0
+					upgrades = {
+						ship_reliability_upgrade = 1
+						ship_engine_upgrade = 0
+						ship_armor_upgrade = 0
+						ship_gun_upgrade = 4
+					}
+					obsolete=yes
+				}
+				create_equipment_variant = {
+					name = "Leipzig Class"
+					type = light_cruiser_1
+					parent_version = 0
+					upgrades = {
+						ship_reliability_upgrade = 2
+						ship_engine_upgrade = 2
+						ship_gun_upgrade = 3
+						ship_anti_air_upgrade = 3
+					}
+					obsolete = yes
+				}
+				# Light Cruisers #
+				create_equipment_variant = {
+					name = "Königsberg Class"
+					type = light_cruiser_1
+					parent_version = 0
+					upgrades = {
+						ship_reliability_upgrade = 2
+						ship_engine_upgrade = 2
+						ship_gun_upgrade = 3
+						ship_anti_air_upgrade = 2
+					}
+					obsolete = yes
+				}
+				create_equipment_variant = {
+					name = "1924 Type"
+					type = destroyer_1
+					parent_version = 0
+					upgrades = {
+						ship_torpedo_upgrade = 1
+						destroyer_engine_upgrade = 1
+						ship_ASW_upgrade = 0
+						ship_anti_air_upgrade = 1
+					}
+					obsolete = yes
+				}
+				create_equipment_variant = {
+					name = "Zerstörer 1934A"
+					type = destroyer_2
+					parent_version = 0
+					upgrades = {
+						ship_torpedo_upgrade = 1
+						destroyer_engine_upgrade = 1
+						ship_ASW_upgrade = 1
+						ship_anti_air_upgrade = 1
+					}
+				}
+				create_equipment_variant = {
+					name = "Type IIB"
+					type = submarine_2
+					parent_version = 0
+					upgrades = {
+						ship_reliability_upgrade = 1
+						sub_engine_upgrade = 0
+						sub_stealth_upgrade = 1
+						sub_torpedo_upgrade = 0
+					}
+					obsolete = yes
+				}
+				create_equipment_variant = {
+					name = "Type VIIA"
+					type = submarine_2
+					parent_version = 0
+					upgrades = {
+						ship_reliability_upgrade = 4
+						sub_engine_upgrade = 3
+						sub_stealth_upgrade = 2
+						sub_torpedo_upgrade = 1
+					}
+				}
+				create_equipment_variant = {
+					name = "Type IA"
+					type = submarine_1
+					parent_version = 0
+					upgrades = {
+						ship_reliability_upgrade = 1
+						sub_engine_upgrade = 2
+						sub_stealth_upgrade = 2
+						sub_torpedo_upgrade = 2
+					}
+					obsolete = yes
+				}
+			}
+			if = {
+				limit = { has_dlc = "Man the Guns" }
+				create_equipment_variant = { #Are we making a CV or a Monster Cruiser? Make up your mind
+					name = "Graf Zeppelin Class"
+					type = ship_hull_carrier_conversion_ca
+					name_group = GER_CV_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_deck_slot_1 = ship_deck_space
+						fixed_ship_deck_slot_2 = ship_deck_space
+						fixed_ship_anti_air_slot = ship_anti_air_2
+						fixed_ship_radar_slot = empty
+						fixed_ship_engine_slot = cruiser_ship_engine_2
+						fixed_ship_secondaries_slot = ship_secondaries_2 
+					}
+				}
+				create_equipment_variant = {
+					name = "Deutschland Class"
+					type = ship_hull_cruiser_panzerschiff
+					name_group = GER_CA_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_anti_air_slot = ship_anti_air_1
+						fixed_ship_battery_slot = ship_heavy_battery_2
+						fixed_ship_secondaries_slot = ship_secondaries_1
+						fixed_ship_armor_slot = ship_armor_cruiser_2
+						fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+						fixed_ship_engine_slot = cruiser_ship_engine_2
+						front_1_custom_slot = ship_anti_air_1
+						mid_1_custom_slot = ship_airplane_launcher_1
+						mid_2_custom_slot = ship_secondaries_1
+						rear_1_custom_slot = ship_torpedo_1
+					}
+				}
+				create_equipment_variant = {
+					name = "Type 24 Class"
+					type = ship_hull_light_1
+					name_group = GER_TB_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_battery_slot = ship_light_battery_1
+						fixed_ship_anti_air_slot = empty
+						fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+						fixed_ship_radar_slot = empty
+						fixed_ship_engine_slot = light_ship_engine_1
+						fixed_ship_torpedo_slot = ship_torpedo_1
+						rear_1_custom_slot = ship_mine_layer_1
+					}
+					obsolete = yes
+				}
+				create_equipment_variant = {
+					name = "Zerstörer 1934 Class"
+					type = ship_hull_light_2
+					name_group = GER_DD_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_battery_slot = ship_light_battery_2
+						fixed_ship_anti_air_slot = ship_anti_air_1
+						fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+						fixed_ship_radar_slot = empty
+						fixed_ship_engine_slot = light_ship_engine_2
+						fixed_ship_torpedo_slot = ship_torpedo_1
+						mid_1_custom_slot = ship_torpedo_1
+						rear_1_custom_slot = ship_mine_layer_1
+					}
+					obsolete = yes
+				}
+				create_equipment_variant = {
+					name = "Zerstörer 1934A Class"
+					type = ship_hull_light_2
+					name_group = GER_DD_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_battery_slot = ship_light_battery_2
+						fixed_ship_anti_air_slot = ship_anti_air_1
+						fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+						fixed_ship_radar_slot = empty
+						fixed_ship_engine_slot = light_ship_engine_2
+						fixed_ship_torpedo_slot = ship_torpedo_1
+						mid_1_custom_slot = ship_torpedo_1
+						rear_1_custom_slot = ship_depth_charge_1
+					}
+				}
+				create_equipment_variant = {
+					name = "Type I Class"
+					type = ship_hull_submarine_2
+					name_group = GER_SS_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_torpedo_slot = ship_torpedo_sub_1
+						fixed_ship_engine_slot = sub_ship_engine_1
+						rear_1_custom_slot = empty
+					}
+					obsolete = yes
+				}
+				create_equipment_variant = {
+					name = "Type II Class"
+					type = ship_hull_submarine_1
+					name_group = GER_SS_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_torpedo_slot = ship_torpedo_sub_1
+						fixed_ship_engine_slot = sub_ship_engine_1
+						rear_1_custom_slot = empty
+					}
+					obsolete = yes
+				}
+				create_equipment_variant = {
+					name = "Type IX Class"
+					type = ship_hull_submarine_2
+					name_group = GER_SS_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_torpedo_slot = ship_torpedo_sub_2
+						fixed_ship_engine_slot = sub_ship_engine_2
+						rear_1_custom_slot = empty
+					}
+				}
+				create_equipment_variant = {
+					name = "Type VII Class"
+					type = ship_hull_submarine_2
+					name_group = GER_SS_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_torpedo_slot = ship_torpedo_sub_2
+						fixed_ship_engine_slot = sub_ship_engine_1
+						rear_1_custom_slot = empty
+					}
+				}
+				create_equipment_variant = {
+					name = "Königsberg Class"
+					type = ship_hull_cruiser_2
+					name_group = GER_CL_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_battery_slot = ship_light_medium_battery_1
+						fixed_ship_anti_air_slot = ship_anti_air_1
+						fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+						fixed_ship_radar_slot = empty
+						fixed_ship_engine_slot = cruiser_ship_engine_1
+						fixed_ship_armor_slot = ship_armor_cruiser_1
+						mid_1_custom_slot = ship_torpedo_1
+						mid_2_custom_slot = ship_light_medium_battery_1
+						rear_1_custom_slot = ship_mine_layer_1
+					}
+					obsolete = yes
+				}
+				create_equipment_variant = {
+					name = "Emden Class"
+					type = ship_hull_cruiser_1
+					name_group = GER_CL_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_battery_slot = ship_light_medium_battery_1
+						fixed_ship_anti_air_slot = empty
+						fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+						fixed_ship_radar_slot = empty
+						fixed_ship_engine_slot = cruiser_ship_engine_1
+						fixed_ship_armor_slot = ship_armor_cruiser_1
+						mid_1_custom_slot = ship_light_medium_battery_1
+						mid_2_custom_slot = ship_torpedo_1
+						rear_1_custom_slot = empty
+					}
+					obsolete = yes
+				}
+				create_equipment_variant = {
+					name = "Bremse Class"
+					type = ship_hull_cruiser_1
+					name_group = GER_CL_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_battery_slot = ship_light_battery_1
+						fixed_ship_anti_air_slot = ship_anti_air_1
+						fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+						fixed_ship_radar_slot = empty
+						fixed_ship_engine_slot = cruiser_ship_engine_1
+						mid_1_custom_slot = ship_anti_air_1
+						mid_2_custom_slot = ship_mine_layer_1
+						rear_1_custom_slot = ship_mine_layer_1
+					}
+					obsolete = yes
+				}
+				create_equipment_variant = {
+					name = "Leipzig Class"
+					type = ship_hull_cruiser_2
+					name_group = GER_CL_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_battery_slot = ship_light_medium_battery_1
+						fixed_ship_anti_air_slot = ship_anti_air_2
+						fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+						fixed_ship_radar_slot = empty
+						fixed_ship_engine_slot = cruiser_ship_engine_1
+						fixed_ship_armor_slot = ship_armor_cruiser_1
+						front_1_custom_slot = ship_light_medium_battery_1
+						mid_1_custom_slot = ship_torpedo_1
+						mid_2_custom_slot = ship_mine_layer_1
+						rear_1_custom_slot = ship_airplane_launcher_1
+					}
+				}
+				create_equipment_variant = {
+					name = "Admiral Hipper Class"
+					type = ship_hull_cruiser_2
+					name_group = GER_CA_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_battery_slot = ship_medium_battery_2
+						fixed_ship_anti_air_slot = ship_anti_air_1
+						fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+						fixed_ship_radar_slot = empty
+						fixed_ship_engine_slot = cruiser_ship_engine_1
+						fixed_ship_armor_slot = ship_armor_cruiser_2
+						front_1_custom_slot = ship_anti_air_1
+						mid_1_custom_slot = ship_torpedo_1
+						mid_2_custom_slot = ship_airplane_launcher_1
+						rear_1_custom_slot = ship_medium_battery_2
+					}
+				}
+				create_equipment_variant = {
+					name = "Scharnhorst Class"
+					type = ship_hull_heavy_2
+					name_group = GER_BB_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_battery_slot = ship_heavy_battery_2
+						fixed_ship_anti_air_slot = ship_anti_air_1
+						fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+						fixed_ship_radar_slot = empty
+						fixed_ship_engine_slot = heavy_ship_engine_2
+						fixed_ship_secondaries_slot = ship_secondaries_1
+						fixed_ship_armor_slot = ship_armor_bb_1
+						front_1_custom_slot = ship_anti_air_1
+						mid_1_custom_slot = empty
+						mid_2_custom_slot = ship_secondaries_1
+						rear_1_custom_slot = ship_heavy_battery_2
+					}
+				}
+				create_equipment_variant = {
+					name = "Deutschland Class"
+					type = ship_hull_pre_dreadnought
+					name_group = GER_BB_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_battery_slot = ship_heavy_battery_1
+						fixed_ship_anti_air_slot = ship_anti_air_1
+						fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+						fixed_ship_radar_slot = empty
+						fixed_ship_engine_slot = heavy_ship_engine_1
+						fixed_ship_secondaries_slot = ship_secondaries_1
+						fixed_ship_armor_slot = ship_armor_bb_1
+						front_1_custom_slot = ship_anti_air_1
+						mid_1_custom_slot = ship_secondaries_1
+						rear_1_custom_slot = ship_torpedo_1
+					}
+					obsolete = yes
+				}
+			}
+			create_equipment_variant = {
+				name = "Ju 86"
+				type = tac_bomber_equipment_0
+				upgrades = {
+					plane_tac_bomb_upgrade = 5
+					plane_range_upgrade = 5
+					plane_engine_upgrade = 5
+					plane_reliability_upgrade = 10
+				}
+				obsolete = yes
+			}
+			create_equipment_variant = {
+				name = "Do 17"
+				type = tac_bomber_equipment_0
+				upgrades = {
+					plane_tac_bomb_upgrade = 5
+					plane_range_upgrade = 1
+					plane_engine_upgrade = 1
+					plane_reliability_upgrade = 5
+				}
+				obsolete = yes
+			}
+			if = {
+				limit = {
+					has_dlc = "No Step Back"
+				}
+				create_equipment_variant = {
+					name = "Leichttraktor"
+					type = light_tank_chassis_0
+					parent_version = 0
+					modules = {
+						main_armament_slot = tank_small_cannon
+						turret_type_slot = tank_light_two_man_tank_turret
+						suspension_type_slot = tank_christie_suspension
+						armor_type_slot = tank_riveted_armor
+						engine_type_slot = tank_gasoline_engine
+						special_type_slot_1 = tank_radio_1
+					}
+					upgrades = {
+						tank_nsb_engine_upgrade = 2
+						tank_nsb_armor_upgrade = 2
+					}
+					obsolete = yes
+					icon = "gfx/interface/technologies/gwtank.dds"
+				}
+				create_equipment_variant = {
+					name = "Panzer I Ausf. A"
+					type = light_tank_chassis_1
+					parent_version = 0
+					modules = {
+						main_armament_slot = tank_heavy_machine_gun
+						turret_type_slot = tank_light_one_man_tank_turret
+						suspension_type_slot = tank_christie_suspension
+						armor_type_slot = tank_riveted_armor
+						engine_type_slot = tank_gasoline_engine
+						special_type_slot_1 = tank_radio_1
+					}
+					upgrades = {
+						tank_nsb_engine_upgrade = 5
+						tank_nsb_armor_upgrade = 1
+					}
+					icon = "gfx/interface/technologies/ger_basic_light_tank.dds"
+					obsolete = yes
+				}
+				create_equipment_variant = {
+					name = "Neubaufahrzeug"
+					type = heavy_tank_chassis_1
+					parent_version = 0
+					modules = {
+						main_armament_slot = tank_close_support_gun
+						turret_type_slot = tank_heavy_three_man_tank_turret
+						suspension_type_slot = tank_bogie_suspension
+						armor_type_slot = tank_riveted_armor
+						engine_type_slot = tank_gasoline_engine
+						special_type_slot_1 = tank_radio_1
+						special_type_slot_2 = secondary_turret_hmg
+						special_type_slot_3 = secondary_turret_hmg
+						special_type_slot_4 = secondary_turret_hmg
+					}
+					upgrades = {
+						tank_nsb_engine_upgrade = 6
+						tank_nsb_armor_upgrade = 2
+					}
+					icon = "gfx/interface/technologies/ger_basic_heavy_tank.dds"
+				}
+				create_equipment_variant = {
+					name = "Panzer II Ausf. a"
+					type = light_tank_chassis_2
+					parent_version = 0
+					modules = {
+						main_armament_slot = tank_auto_cannon
+						turret_type_slot = tank_light_two_man_tank_turret
+						suspension_type_slot = tank_christie_suspension
+						armor_type_slot = tank_riveted_armor
+						engine_type_slot = tank_gasoline_engine
+						special_type_slot_1 = tank_radio_1
+					}
+					upgrades = {
+						tank_nsb_engine_upgrade = 3
+						tank_nsb_armor_upgrade = 2
+					}
+					icon = "gfx/interface/technologies/ger_imp_light_tank.dds"
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Reworked the way the German civil war works, so players don't crash when opening the officer corps and lose all their equipment designs. Almost completed, only needs war between the different sides to be properly started.
The player stays the original tag instead of being switched to a new dynamic one, the basegame has a bug that apparently causes crashes when such player countries access the officer corps, it also will keep equipment designs.