### PR TITLE
Changes to the Naval OOB for MTG Sweden

### DIFF
--- a/common/national_focus/sweden.txt
+++ b/common/national_focus/sweden.txt
@@ -5645,7 +5645,60 @@ focus_tree = {
 					uses = 1
 					category = asw_tech
 				}
+				create_equipment_variant = {
+					name = "Delfinen Class"	
+					type = ship_hull_submarine_2
+					name_group = SWE_SS_HISTORICAL
+					parent_version = 0
+					modules = {
+						fixed_ship_torpedo_slot = ship_torpedo_sub_2
+						fixed_ship_engine_slot = sub_ship_engine_2
+						rear_1_custom_slot = ship_mine_layer_sub
+					}					
+				}
+				add_equipment_production = {
+					equipment = {
+						type = ship_hull_submarine_2
+						creator = "SWE" 
+						version_name = "Delfinen Class"
+					}
+					name = "HM Delfinen"
+					requested_factories = 1
+					progress = 0.5
+					amount = 1
+				}
+				add_equipment_production = {
+					equipment = {
+						type = ship_hull_submarine_2
+						creator = "SWE" 
+						version_name = "Delfinen Class"
+					}
+					name = "HM Nordkaparen"
+					requested_factories = 1
+					progress = 0.5
+					amount = 1
+				}				
 			}
+			else = {
+				add_equipment_production = {
+					equipment = {
+						type = submarine_2
+						creator = "SWE" 
+					}
+					requested_factories = 1
+					progress = 0.5
+					amount = 1
+				}
+				add_equipment_production = {
+					equipment = {
+						type = submarine_2
+						creator = "SWE" 
+					}
+					requested_factories = 1
+					progress = 0.5
+					amount = 1
+				}				
+			}			
 		}
 		search_filters = { FOCUS_FILTER_RESEARCH }
 	}	

--- a/history/countries/SWE - Sweden.txt
+++ b/history/countries/SWE - Sweden.txt
@@ -168,6 +168,7 @@ if = {
 		#basic_secondary_battery = 1
 		basic_cruiser_armor_scheme = 1
 		basic_torpedo = 1
+		improved_ship_torpedo_launcher = 1
 		basic_depth_charges = 1
 		coastal_defense_ships = 1
 		mtg_transport = 1
@@ -401,57 +402,68 @@ if = {
 	limit = { has_dlc = "Man the Guns" }
 	# Submarines #
 	create_equipment_variant = {
-		name = "Hajen Class"					# represents Hajen and Bävern classes	
+		name = "Braxen Class"					# World War 1 Era
 		type = ship_hull_submarine_1
 		name_group = SWE_SS_HISTORICAL
 		parent_version = 0
 		modules = {
 			fixed_ship_torpedo_slot = ship_torpedo_sub_1
-			fixed_ship_engine_slot = sub_ship_engine_1
+			fixed_ship_engine_slot = sub_ship_engine_2
 			rear_1_custom_slot = empty
 		}
 		obsolete = yes
 	}
 	create_equipment_variant = {
-		name = "Valen Class"				
+		name = "Hajen Class"					# World War 1 Era
 		type = ship_hull_submarine_1
 		name_group = SWE_SS_HISTORICAL
 		parent_version = 0
 		modules = {
 			fixed_ship_torpedo_slot = ship_torpedo_sub_1
-			fixed_ship_engine_slot = sub_ship_engine_1
-			rear_1_custom_slot = ship_mine_layer_sub
+			fixed_ship_engine_slot = sub_ship_engine_2
+			rear_1_custom_slot = empty
 		}
 		obsolete = yes
 	}
 	create_equipment_variant = {
-		name = "Draken Class"				
-		type = ship_hull_submarine_2
+		name = "Bävern Class"					# World War 1 Era
+		type = ship_hull_submarine_1
 		name_group = SWE_SS_HISTORICAL
 		parent_version = 0
 		modules = {
 			fixed_ship_torpedo_slot = ship_torpedo_sub_1
-			fixed_ship_engine_slot = sub_ship_engine_1
+			fixed_ship_engine_slot = sub_ship_engine_2
+			rear_1_custom_slot = empty
+		}
+		obsolete = yes
+	}		
+	create_equipment_variant = {
+		name = "Draken Class"					# World War 2 Era
+		type = ship_hull_submarine_2
+		name_group = SWE_SS_HISTORICAL
+		parent_version = 0
+		modules = {
+			fixed_ship_torpedo_slot = ship_torpedo_sub_2
+			fixed_ship_engine_slot = sub_ship_engine_2
 			rear_1_custom_slot = empty
 		}
 	}
 	# Destroyers #
 	create_equipment_variant = {
-		name = "Örnen Class"					# torpedo boats		
-		type = ship_hull_light_1
+		name = "Göteborg Class"	
+		type = ship_hull_light_2
 		name_group = SWE_DD_HISTORICAL
 		parent_version = 0
 		modules = {
 			fixed_ship_battery_slot = ship_light_battery_1
-			fixed_ship_anti_air_slot = empty
+			fixed_ship_anti_air_slot = ship_anti_air_1
 			fixed_ship_fire_control_system_slot = ship_fire_control_system_0
 			fixed_ship_radar_slot = empty
-			fixed_ship_engine_slot = light_ship_engine_1
-			fixed_ship_torpedo_slot = empty
-			mid_1_custom_slot = empty
-			rear_1_custom_slot = empty
+			fixed_ship_torpedo_slot = ship_torpedo_1
+			fixed_ship_engine_slot = light_ship_engine_2
+			mid_1_custom_slot = ship_mine_layer_1
+			rear_1_custom_slot = ship_depth_charge_1
 		}
-		obsolete = yes
 	}
 	create_equipment_variant = {
 		name = "Ehrensköld Class"				# represents Ehrensköld	and Klas Horn classes
@@ -463,15 +475,15 @@ if = {
 			fixed_ship_anti_air_slot = ship_anti_air_1
 			fixed_ship_fire_control_system_slot = ship_fire_control_system_0
 			fixed_ship_radar_slot = empty
-			fixed_ship_engine_slot = light_ship_engine_1
 			fixed_ship_torpedo_slot = ship_torpedo_1
+			fixed_ship_engine_slot = light_ship_engine_2
 			mid_1_custom_slot = ship_mine_layer_1
-			rear_1_custom_slot = ship_depth_charge_1
+			rear_1_custom_slot = ship_anti_air_1
 		}
 		obsolete = yes
 	}
 	create_equipment_variant = {
-		name = "Clas Fleming Class"				# minelayer		
+		name = "Wrangel Class"				# Wrangel and Vidar classes were the same.
 		type = ship_hull_light_1
 		name_group = SWE_DD_HISTORICAL
 		parent_version = 0
@@ -480,16 +492,16 @@ if = {
 			fixed_ship_anti_air_slot = empty
 			fixed_ship_fire_control_system_slot = ship_fire_control_system_0
 			fixed_ship_radar_slot = empty
+			fixed_ship_torpedo_slot = ship_torpedo_1
 			fixed_ship_engine_slot = light_ship_engine_1
-			fixed_ship_torpedo_slot = empty
-			mid_1_custom_slot = ship_mine_layer_1
-			rear_1_custom_slot = ship_mine_layer_1
+			mid_1_custom_slot = ship_torpedo_1
+			rear_1_custom_slot = empty
 		}
 		obsolete = yes
 	}
 	create_equipment_variant = {
-		name = "Göteborg Class"	
-		type = ship_hull_light_2
+		name = "Klas Class"				# Wrangel and Vidar classes were the same.
+		type = ship_hull_light_1
 		name_group = SWE_DD_HISTORICAL
 		parent_version = 0
 		modules = {
@@ -497,16 +509,55 @@ if = {
 			fixed_ship_anti_air_slot = ship_anti_air_1
 			fixed_ship_fire_control_system_slot = ship_fire_control_system_0
 			fixed_ship_radar_slot = empty
-			fixed_ship_engine_slot = light_ship_engine_2
-			fixed_ship_torpedo_slot = ship_torpedo_1
+			fixed_ship_torpedo_slot = ship_torpedo_2
+			fixed_ship_engine_slot = light_ship_engine_1
 			mid_1_custom_slot = ship_mine_layer_1
 			rear_1_custom_slot = ship_depth_charge_1
 		}
-	}
+		obsolete = yes
+	}			
 	# Cruisers #
 	create_equipment_variant = {
-		name = "Fylgia Class"				
-		type = ship_hull_cruiser_coastal_defense_ship
+		name = "Fylgia Class"						# was actually a light cruiser, not a coastal defense ship
+		type = ship_hull_cruiser_1
+		name_group = SWE_CL_HISTORICAL
+		parent_version = 0
+		modules = {
+			fixed_ship_battery_slot = ship_light_medium_battery_1
+			fixed_ship_anti_air_slot = ship_anti_air_1
+			fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+			fixed_ship_radar_slot = empty
+			fixed_ship_engine_slot = cruiser_ship_engine_1
+			fixed_ship_secondaries_slot = ship_secondaries_1
+			fixed_ship_armor_slot = ship_armor_cruiser_1
+			mid_1_custom_slot = ship_light_medium_battery_1
+			mid_2_custom_slot = ship_torpedo_1
+			rear_1_custom_slot = ship_depth_charge_1
+		}
+		obsolete = yes
+	}
+	create_equipment_variant = {
+		name = "Clas Fleming Class"				# minelaying cruiser, not a destroyer	
+		type = ship_hull_cruiser_1
+		name_group = SWE_CL_HISTORICAL
+		parent_version = 0
+		modules = {
+			fixed_ship_battery_slot = ship_light_battery_1
+			fixed_ship_anti_air_slot = empty
+			fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+			fixed_ship_radar_slot = empty
+			fixed_ship_engine_slot = cruiser_ship_engine_1
+			fixed_ship_secondaries_slot = empty
+			fixed_ship_armor_slot = ship_armor_cruiser_1
+			mid_1_custom_slot = ship_light_battery_1
+			mid_2_custom_slot = ship_mine_layer_1
+			rear_1_custom_slot = ship_mine_layer_1
+		}
+		obsolete = yes
+	}
+	create_equipment_variant = {
+		name = "Gotland Class"
+		type = ship_hull_cruiser_2
 		name_group = SWE_CL_HISTORICAL
 		parent_version = 0
 		modules = {
@@ -515,14 +566,15 @@ if = {
 			fixed_ship_fire_control_system_slot = ship_fire_control_system_0
 			fixed_ship_radar_slot = empty
 			fixed_ship_engine_slot = cruiser_ship_engine_1
-			fixed_ship_armor_slot = ship_armor_cruiser_1
+			fixed_ship_armor_slot = empty
 			fixed_ship_secondaries_slot = ship_secondaries_1
-			mid_1_custom_slot = ship_anti_air_1
-			mid_2_custom_slot = ship_secondaries_1
-			rear_1_custom_slot = ship_torpedo_1
+			front_1_custom_slot = ship_medium_battery_1
+			mid_1_custom_slot = ship_airplane_launcher_1
+			mid_2_custom_slot = ship_torpedo_1
+			rear_1_custom_slot = ship_mine_layer_1
 		}
-		obsolete = yes
-	}
+	}	
+	# Coastal Defense Ships	
 	create_equipment_variant = {
 		name = "Äran Class"				
 		type = ship_hull_cruiser_coastal_defense_ship
@@ -542,6 +594,26 @@ if = {
 		}
 		obsolete = yes
 	}
+	create_equipment_variant = {
+		name = "Oden Class"				
+		type = ship_hull_cruiser_coastal_defense_ship
+		name_group = SWE_CA_HISTORICAL
+		parent_version = 0
+		modules = {
+			fixed_ship_battery_slot = ship_medium_battery_1
+			fixed_ship_anti_air_slot = ship_anti_air_1
+			fixed_ship_fire_control_system_slot = ship_fire_control_system_0
+			fixed_ship_radar_slot = empty
+			fixed_ship_engine_slot = cruiser_ship_engine_1
+			fixed_ship_armor_slot = ship_armor_cruiser_2
+			fixed_ship_secondaries_slot = ship_secondaries_1
+			front_1_custom_slot = empty
+			mid_1_custom_slot = ship_airplane_launcher_1
+			mid_2_custom_slot = empty
+			rear_1_custom_slot = empty
+		}
+		obsolete = yes
+	}	
 	create_equipment_variant = {
 		name = "Oscar II Class"				
 		type = ship_hull_cruiser_coastal_defense_ship
@@ -579,23 +651,7 @@ if = {
 			rear_1_custom_slot = ship_medium_battery_1
 		}
 	}
-	create_equipment_variant = {
-		name = "Gotland Class"
-		type = ship_hull_cruiser_2
-		name_group = SWE_CL_HISTORICAL
-		parent_version = 0
-		modules = {
-			fixed_ship_battery_slot = ship_medium_battery_1
-			fixed_ship_anti_air_slot = ship_anti_air_1
-			fixed_ship_fire_control_system_slot = ship_fire_control_system_0
-			fixed_ship_radar_slot = empty
-			fixed_ship_engine_slot = cruiser_ship_engine_1
-			fixed_ship_armor_slot = empty
-			mid_1_custom_slot = ship_airplane_launcher_1
-			mid_2_custom_slot = ship_torpedo_1
-			rear_1_custom_slot = empty
-		}
-	}
+
 }
 if = {
 	limit = {

--- a/history/units/SWE_1936_naval_mtg.txt
+++ b/history/units/SWE_1936_naval_mtg.txt
@@ -7,54 +7,57 @@
 		task_force = {				
 			name = "Kustflottan"
 			location = 6050 # Stockholm
-			ship = { name = "HMS Dristigheten" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Äran Class" } } }				
-			ship = { name = "HMS Örnen" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Örnen Class" } } }		
-			ship = { name = "HMS Jacob Bagge" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Örnen Class" } } }		
-			ship = { name = "HMS Clas Fleming" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Clas Fleming Class" } } }				
+			ship = { name = "HM Dristigheten" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Oden Class" } } }				
+			ship = { name = "HM Wrangel" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Wrangel Class" } } }		
+			ship = { name = "HM Vidar" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Wrangel Class" } } }	
+			ship = { name = "HM Clas Fleming" definition = light_cruiser equipment = { ship_hull_cruiser_1 = { amount = 1 owner = SWE version_name = "Clas Fleming Class" } } }				
 		}
 		task_force = { 
 			name = "1a Eskadern"
 			location = 11215 # Karlskrona
-			ship = { name = "HMS Gustaf V" pride_of_the_fleet = yes definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Sverige Class" } } }				
-			ship = { name = "HMS Sverige" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Sverige Class" } } }				
-			ship = { name = "HMS Drottning Victoria" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Sverige Class" } } }				
-			ship = { name = "HMS Gotland" definition = light_cruiser equipment = { ship_hull_cruiser_2 = { amount = 1 owner = SWE version_name = "Gotland Class" } } }				
+			ship = { name = "HM Gustaf V" pride_of_the_fleet = yes definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Sverige Class" } } }				
+			ship = { name = "HM Sverige" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Sverige Class" } } }				
+			ship = { name = "HM Drottning Victoria" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Sverige Class" } } }				
+			ship = { name = "HM Gotland" definition = heavy_cruiser equipment = { ship_hull_cruiser_2 = { amount = 1 owner = SWE version_name = "Gotland Class" } } }				
 			# 1. Jagarflottiljen				
-			ship = { name = "HMS Klas Horn" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Ehrensköld Class" } } }		
-			ship = { name = "HMS Klas Uggla" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Ehrensköld Class" } } }		
-			ship = { name = "HMS Ehrensköld" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Ehrensköld Class" } } }		
-			ship = { name = "HMS Nordenskjöld" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Ehrensköld Class" } } }		
+			ship = { name = "HM Klas Horn" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Klas Class" } } }		
+			ship = { name = "HM Klas Uggla" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Klas Class" } } }		
+			ship = { name = "HM Ehrensköld" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Ehrensköld Class" } } }		
+			ship = { name = "HM Nordenskjöld" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Ehrensköld Class" } } }
+			ship = { name = "HM Wale" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Wrangel Class" } } }
+			ship = { name = "HM Wachtmeister" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Wrangel Class" } } }			
+			ship = { name = "HM Ragnar" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Wrangel Class" } } }
+			ship = { name = "HM Sigurd" definition = destroyer equipment = { ship_hull_light_1 = { amount = 1 owner = SWE version_name = "Wrangel Class" } } }						
 		}
 		task_force = { 
 			name = "Ålandshavseskader"
 			location = 408 # Gotland
-			ship = { name = "HMS Äran" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Äran Class" } } }				
-			ship = { name = "HMS Tapperheten" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Äran Class" } } }				
+			ship = { name = "HM Äran" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Äran Class" } } }				
+			ship = { name = "HM Tapperheten" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Äran Class" } } }				
 		}
 		task_force = { 
 			name = "Karlskrona Avdelningen"
 			location = 11215 # Karlskrona
-			ship = { name = "HMS Wasa" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Äran Class" } } }				
-			ship = { name = "HMS Manligheten" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Äran Class" } } }
+			ship = { name = "HM Manligheten" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Äran Class" } } }
 			# 1. Ubatsflottiljen				
-			ship = { name = "HMS Draken" definition = submarine equipment = { ship_hull_submarine_2 = { amount = 1 owner = SWE version_name = "Draken Class" } } }
-			ship = { name = "HMS Gripen" definition = submarine equipment = { ship_hull_submarine_2 = { amount = 1 owner = SWE version_name = "Draken Class" } } }
-			ship = { name = "HMS Ulven" definition = submarine equipment = { ship_hull_submarine_2 = { amount = 1 owner = SWE version_name = "Draken Class" } } }
+			ship = { name = "HM Draken" definition = submarine equipment = { ship_hull_submarine_2 = { amount = 1 owner = SWE version_name = "Draken Class" } } }
+			ship = { name = "HM Gripen" definition = submarine equipment = { ship_hull_submarine_2 = { amount = 1 owner = SWE version_name = "Draken Class" } } }
+			ship = { name = "HM Ulven" definition = submarine equipment = { ship_hull_submarine_2 = { amount = 1 owner = SWE version_name = "Draken Class" } } }
 		}
 		task_force = { 
 			name = "Göteborgs Eskadern"
 			location = 383 # Göteborg
-			ship = { name = "HMS Oscar II" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Oscar II Class" } } }				
-			ship = { name = "HMS Fylgia" definition = light_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Fylgia Class" } } }				
+			ship = { name = "HM Oscar II" definition = heavy_cruiser equipment = { ship_hull_cruiser_coastal_defense_ship = { amount = 1 owner = SWE version_name = "Oscar II Class" } } }				
+			ship = { name = "HM Fylgia" definition = light_cruiser equipment = { ship_hull_cruiser_1 = { amount = 1 owner = SWE version_name = "Fylgia Class" } } }				
 			# 2. Ubatsflottiljen				
-			ship = { name = "HMS Hajen" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Hajen Class" } } }
-			ship = { name = "HMS Sälen" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Hajen Class" } } }
-			ship = { name = "HMS Valrossen" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Hajen Class" } } }
+			ship = { name = "HM Hajen" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Hajen Class" } } }
+			ship = { name = "HM Sälen" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Hajen Class" } } }
+			ship = { name = "HM Valrossen" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Hajen Class" } } }
 			# 3. Ubatsflottiljen				
-			ship = { name = "HMS Bävern" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Hajen Class" } } }
-			ship = { name = "HMS Illern" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Hajen Class" } } }
-			ship = { name = "HMS Uttern" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Hajen Class" } } }
-			ship = { name = "HMS Valen" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Valen Class" } } }
+			ship = { name = "HM Bävern" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Bävern Class" } } }
+			ship = { name = "HM Braxen" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Braxen Class" } } }
+			ship = { name = "HM Aborren" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Braxen Class" } } }
+			ship = { name = "HM Illern" definition = submarine equipment = { ship_hull_submarine_1 = { amount = 1 owner = SWE version_name = "Bävern Class" } } }
 		}
 	}
 }
@@ -63,50 +66,38 @@
 ### Starting Production ###
 instant_effect = {
 	### Under Construction Notes ###
-	# DD: Göteborg class (x1) ("HMS Göteborg")
+	# DD: Göteborg class (x1) ("HM Göteborg")
 	add_equipment_production = {
 		equipment = {
 			type = ship_hull_light_2
 			creator = "SWE"
 			version_name = "Göteborg Class"
 		}
-		name = "HMS Göteborg" 
+		name = "HM Göteborg" 
 		requested_factories = 1
-		progress = 0.50
-		amount = 1
-	}
-	# SS: Draken variant (x3) ("HMS Delfinen" "HMS Nordkaparen" "HMS Springaren")
-	add_equipment_production = {
-		equipment = {
-			type = ship_hull_submarine_2
-			creator = "SWE"
-			version_name = "Draken Class"
-		}
-		name = "HMS Delfinen" 
-		requested_factories = 1
-		progress = 0.80
+		progress = 0.8
 		amount = 1
 	}
 	add_equipment_production = {
 		equipment = {
-			type = ship_hull_submarine_2
+			type = ship_hull_light_2
 			creator = "SWE"
-			version_name = "Draken Class"
+			version_name = "Göteborg Class"
 		}
-		name = "HMS Nordkaparen" 
+		name = "HM Stockholm" 
 		requested_factories = 1
-		progress = 0.60
-		amount = 1
+		progress = 0.2
+		amount = 2
 	}
 	add_equipment_production = {
 		equipment = {
-			type = ship_hull_submarine_2
+			type = ship_hull_light_2
 			creator = "SWE"
-			version_name = "Draken Class"
+			version_name = "Göteborg Class"
 		}
-		name = "HMS Springaren" 
+		name = "HM Malmö" 
 		requested_factories = 1
-		progress = 0.40
-		amount = 1
-	}
+		progress = 0.2
+		amount = 0
+	}		
 }

--- a/history/units/SWE_1936_naval_mtg.txt
+++ b/history/units/SWE_1936_naval_mtg.txt
@@ -87,7 +87,7 @@ instant_effect = {
 		name = "HM Stockholm" 
 		requested_factories = 1
 		progress = 0.2
-		amount = 2
+		amount = 1
 	}
 	add_equipment_production = {
 		equipment = {
@@ -98,6 +98,6 @@ instant_effect = {
 		name = "HM Malmö" 
 		requested_factories = 1
 		progress = 0.2
-		amount = 0
+		amount = 1
 	}		
 }


### PR DESCRIPTION
Changed the design of the following ships types: 
- Gotland Class
- Ehrensköld Class
- Clas Fleming Class
- Fylgia Class

Removed:
- Hajen Class
- Valen Class
- Örnen Class

Added:
- Oden Class
- Wrangel Class
- Klas Class
- Bävern Class
- Braxen Class

Updated the Swedish Hunter-Killer focus to add in production line of Delfinen Class Submarines.

Error log is void of any additions.

Overall this should be net neutral for Sweden's navy.