### PR TITLE
Added a victory point to British Honduras

### DIFF
--- a/history/states/311-BritMex.txt
+++ b/history/states/311-BritMex.txt
@@ -7,7 +7,7 @@ state= {
 	history={
 		add_core_of = BLZ
 		victory_points = {
-			2077 2 
+			2077 1
 		}
 		owner = ENG
 		buildings = {

--- a/history/states/311-BritMex.txt
+++ b/history/states/311-BritMex.txt
@@ -6,6 +6,9 @@ state= {
 	state_category = enclave
 	history={
 		add_core_of = BLZ
+		victory_points = {
+			2077 2 
+		}
 		owner = ENG
 		buildings = {
 			infrastructure = 2 #was 3


### PR DESCRIPTION
British Honduras had no victory point which made the decolonized Belize have a capital with the wrong name. That is now fixed