### PR TITLE
Removed redundant events

### DIFF
--- a/events/r56_hungary.txt
+++ b/events/r56_hungary.txt
@@ -116,59 +116,6 @@ country_event = {
 	}
 }
 
-country_event = {
-	id = r56_hungary_coastline.4
-	title = r56_hungary_coastline.4.t
-	desc = r56_hungary_coastline.4.d
-	picture = GFX_report_event_hitler_handshake
-	
-	mean_time_to_happen = { days = 2 }
-
-	trigger = {
-		tag = ITA
-		owns_state = 958
-		HUN = {
-			has_completed_focus = HUN_demand_the_coastline
-			owns_state = 109
-			owns_state = 959
-			NOT = { owns_state = 958 }
-		}
-		109 = {
-			OWNER = {
-				NOT = { has_war_with = HUN }
-			}
-		}
-	}
-	
-	option = { # Here you go Hungary
-		name = r56_hungary_coastline.4.a
-		ai_chance = {
-			factor = 25
-		}
-		effect_tooltip = {
-			HUN = { transfer_state = 958 }
-		}
-		HUN = { country_event = r56_hungary_coastline.5 }
-	}
-}
-
-country_event = {
-	id = r56_hungary_coastline.5
-	title = r56_hungary_coastline.5.t
-	desc = r56_hungary_coastline.5.d
-	picture = GFX_report_event_hitler_handshake
-	
-	is_triggered_only = yes
-	
-	option = { # Excellent
-		name = r56_hungary_coastline.5.a
-		ai_chance = {
-			factor = 25
-		}
-		transfer_state = 958
-	}
-}
-
 add_namespace = r56_hungary_prekmurje_annexation
 
 country_event = {


### PR DESCRIPTION
The `r56_hungary_coastline.3` event already does what events 4 and 5 do, but better. Event 4 doesn't check to see if Italy is AI before firing, and only has one option: hand over the territory. Event 3 already has a choice, and reasonably grants Hungary a CB if Italy declines.