### PR TITLE
Light Tank Recon Nerf

### DIFF
--- a/common/units/equipment/modules/00_r56_modules.txt
+++ b/common/units/equipment/modules/00_r56_modules.txt
@@ -50,7 +50,6 @@ equipment_modules = {
 		allowed_module_categories = {
 			main_armament_slot = {
 				tank_small_main_armament
-				tank_medium_main_armament
 				tank_heavy_main_armament
 			}
 		}


### PR DESCRIPTION
Made it so Light Tank Recon can no longer have medium armaments on it even with the Turret Shield turret