### PR TITLE
Forbid Light Tank Role

### DIFF
--- a/common/units/equipment/modules/00_r56_modules.txt
+++ b/common/units/equipment/modules/00_r56_modules.txt
@@ -4,6 +4,7 @@ equipment_modules = {
 		abbreviation = "pfs"
 		category = tank_light_turret_type
 		sfx = sfx_ui_sd_module_turret
+		forbid_equipment_type_exact_match = armor #### ADDED THIS
 		forbid_equipment_type = {
 			anti_air
 			flame


### PR DESCRIPTION
Made it so the Turret Shield forbids the Light Tank role thus it cannot be used as light tank recon anymore and must be used as artillery