### PR TITLE
Fix focus "Foster Private Investment" for the Indian revolt.

### DIFF
--- a/common/national_focus/r56_india_shared.txt
+++ b/common/national_focus/r56_india_shared.txt
@@ -133,7 +133,7 @@ shared_focus = {
 		else = {
 			OR = {
 				has_government = neutrality
-				has_government = democratic
+				has_government = fascism
 			}
 			NOT = {
 				is_subject_of = ENG


### PR DESCRIPTION
Based on focus requirements, it looks like this was meant to be Authoritarian or Fascist, rather than Authoritarian and Democratic.