### PR TITLE
Update focus bypass for "Restore the Liechtenstein Protectorate"

### DIFF
--- a/common/national_focus/austria.txt
+++ b/common/national_focus/austria.txt
@@ -6464,8 +6464,8 @@ focus_tree = {
 			OR = {
 				has_war_with = LIE
 				NOT = { country_exists = LIE }
-				is_in_faction_with = AUS 
-				is_subject_of = ROOT
+				LIE = { is_in_faction_with = AUS } 
+				LIE = { is_subject_of = ROOT }
 			}
 		}
 		


### PR DESCRIPTION
The focus was bypassing immediately due to it checking if Austria was a puppet of itself or in a faction with itself. Since it comes after Austria becomes a puppet of Germany and joins the Axis, that counted. Changed it to checking if Liechtenstein is a puppet of or in a faction with Austria.