### PR TITLE
Fix missing core for WTT German event.

### DIFF
--- a/events/WTT_Germany.txt
+++ b/events/WTT_Germany.txt
@@ -2652,6 +2652,12 @@ country_event = {
 				add_core_of = GER
 			}
 		}
+		848 = {
+			if = {
+				limit = { is_owned_by = AUS }
+				add_core_of = GER
+			}
+		}
 		AUS = {
 			every_unit_leader = {
 				set_nationality = GER


### PR DESCRIPTION
Added Vorarlberg to list of cored states when peacefully annexing same-faction Austria through event.