### PR TITLE
"Autonomous Soviet Republics" focus oversight fix

### DIFF
--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -10728,7 +10728,6 @@ focus_tree = {
 				create_dynamic_country = {
 					original_tag = BLR
 					set_temp_variable = { new_country = this }
-					add_political_power = 100
 					add_ideas = {
 						SOV_system_decentralization_idea
 						SOV_the_local_soviets_idea

--- a/common/national_focus/soviet.txt
+++ b/common/national_focus/soviet.txt
@@ -10704,7 +10704,7 @@ focus_tree = {
 				}
 			}
 
-			# Axerbaijan
+			# Azerbaijan
 			IF = {
 				limit = { 229 = { is_owned_and_controlled_by = ROOT }}
 				release_autonomy = {
@@ -10721,8 +10721,38 @@ focus_tree = {
 			}
 
 			# Belarus
-			IF = {
-				limit = { 206 = { is_owned_and_controlled_by = ROOT }}
+			if = { ### Prevent SOV from stealing BLR if BLR already exists
+				limit = {
+					country_exists = BLR
+				}
+				create_dynamic_country = {
+					original_tag = BLR
+					set_temp_variable = { new_country = this }
+					add_political_power = 100
+					add_ideas = {
+						SOV_system_decentralization_idea
+						SOV_the_local_soviets_idea
+					}
+					SOV = {
+						every_controlled_state = {
+							limit = {
+								is_core_of = BLR
+							}
+							var:new_country = { transfer_state = PREV }
+						}
+					}
+					SOV = {
+						puppet = var:new_country
+						set_autonomy = {
+							target = var:new_country
+							autonomy_state = autonomy_puppet
+							freedom_level = 0.5
+						}
+					}
+				}
+			}
+			else_if = {
+				limit = { 206 = { is_owned_and_controlled_by = ROOT } }
 				release_autonomy = {
 					target = BLR
 					autonomy_state = autonomy_puppet


### PR DESCRIPTION
Focus "Autonomous Soviet Republics" allowed SOV to puppet BLR and turn the nation communist, even if the tag was already released and a puppet of another nation.

Fix this by making SOV create a dynamic country instead if BLR already exists, achieving the same result but restricted to SOV's territory. The original code still applies if BLR doesn't exist.