### PR TITLE
Fixes to equipment designer modules

### DIFF
--- a/common/technologies/electronic_mechanical_engineering.txt
+++ b/common/technologies/electronic_mechanical_engineering.txt
@@ -989,9 +989,16 @@ technologies = {
 
 		# can build v1s/rocket planes
 		enable_equipments = {
+			limit = {
+				NOT = { has_dlc = "By Blood Alone" }
+			}
 			rocket_interceptor_equipment_1
+		}
+
+		enable_equipments = {
 			guided_missile_equipment_1
 		}
+
 		enable_equipment_modules = {
 			rocket_engine_1
 			AA_rocket_rails
@@ -1043,9 +1050,15 @@ technologies = {
 		show_equipment_icon = yes
 		
 		# can build v2s
+
+		enable_equipments = {
+			limit = {
+				NOT = { has_dlc = "By Blood Alone" }
+			}
+			rocket_interceptor_equipment_2
+		}
 		
 		enable_equipments = {
-			rocket_interceptor_equipment_2
 			guided_missile_equipment_2
 		}
 
@@ -1096,9 +1109,15 @@ technologies = {
 		show_equipment_icon = yes
 		
 		# can build ICBMs?
+
+		enable_equipments = {
+			limit = {
+				NOT = { has_dlc = "By Blood Alone" }
+			}
+			rocket_interceptor_equipment_3
+		}
 		
 		enable_equipments = {
-			rocket_interceptor_equipment_3
 			guided_missile_equipment_3
 		}
 		
@@ -1333,16 +1352,20 @@ technologies = {
 		}
 
 		enable_equipment_modules = {
+			limit = {
+				has_dlc = "Man the Guns"
+			}
 			carrier_ship_engine_nuclear_1
 			heavy_ship_engine_nuclear_1
 			sub_ship_engine_nuclear_1
-		}		
+		}
 		
 		ai_will_do = {
 			factor = 5
 		}
 		
 		categories = {
+			naval_equipment
 			nuclear
 		}
 	}
@@ -2221,7 +2244,7 @@ technologies = {
 		
 		enable_equipments = {
 			guided_missile_equipment_4
-		} 
+		}
 		
 		rocket_artillery = {
 			soft_attack = 0.05

--- a/common/technologies/electronic_mechanical_engineering.txt
+++ b/common/technologies/electronic_mechanical_engineering.txt
@@ -1352,13 +1352,10 @@ technologies = {
 		}
 
 		enable_equipment_modules = {
-			limit = {
-				has_dlc = "Man the Guns"
-			}
 			carrier_ship_engine_nuclear_1
 			heavy_ship_engine_nuclear_1
 			sub_ship_engine_nuclear_1
-		}
+		}		
 		
 		ai_will_do = {
 			factor = 5

--- a/common/units/equipment/modules/00_plane_modules.txt
+++ b/common/units/equipment/modules/00_plane_modules.txt
@@ -1199,6 +1199,7 @@ equipment_modules = {
 		abbreviation = "tpm"
 		category = nav_bomber_weapon
 		sfx = sfx_ui_sd_module_turret
+		parent = torpedo_mounting
 		add_equipment_type = { naval_bomber maritime_patrol_plane }
 
 		add_stats = {
@@ -1231,6 +1232,7 @@ equipment_modules = {
 		abbreviation = "tpm"
 		category = nav_bomber_weapon
 		sfx = sfx_ui_sd_module_turret
+		parent = torpedo_mounting_2
 		add_equipment_type = { naval_bomber maritime_patrol_plane }
 
 		add_stats = {
@@ -1302,6 +1304,7 @@ equipment_modules = {
 		abbreviation = "asm"
 		category = nav_bomber_weapon
 		sfx = sfx_ui_sd_module_turret
+		parent = torpedo_mounting_3
 		add_equipment_type = { naval_bomber maritime_patrol_plane }
 
 		add_stats = {	

--- a/common/units/equipment/modules/00_r56_plane_modules.txt
+++ b/common/units/equipment/modules/00_r56_plane_modules.txt
@@ -2,7 +2,7 @@ equipment_modules = {
 	limit = {
 		has_dlc = "By Blood Alone"
 	}
-	
+
 	AA_rocket_rails = {
 		abbreviation = "aar"
 		category = fighter_weapon
@@ -30,6 +30,7 @@ equipment_modules = {
 			}
 		}
 	}
+
 	guided_AA_rocket_rails = {
 		abbreviation = "aar2"
 		category = fighter_weapon
@@ -49,6 +50,7 @@ equipment_modules = {
 			air_superiority
 			interception
 		}
+
 		mission_type_stats = {
 			limit = {
 				attack_logistics
@@ -58,6 +60,7 @@ equipment_modules = {
 			}
 		}
 	}
+
 	improved_rocket_rails = {
 		abbreviation = "rr2"
 		category = cas_weapon
@@ -85,6 +88,7 @@ equipment_modules = {
 		}
 		dismantle_cost_ic = 0.5
 	}	
+
 	jet_engine_1x_2 = {
 		abbreviation = "j1II"
 		category = plane_jet_engine_type
@@ -143,6 +147,7 @@ equipment_modules = {
 			build_cost_ic = 72
 			fuel_consumption = 1.2
 		}
+
 		build_cost_resources = {
 			tungsten = 2
 		}
@@ -165,9 +170,11 @@ equipment_modules = {
 			build_cost_ic = 100
 			fuel_consumption = 1.8
 		}
+
 		build_cost_resources = {
 			tungsten = 2
 		}
+
 		can_convert_from = {
 			module_category = medium_plane_engine_type
 			convert_cost_ic = 20
@@ -186,9 +193,11 @@ equipment_modules = {
 			build_cost_ic = 135
 			fuel_consumption = 2.2
 		}
+
 		build_cost_resources = {
 			tungsten = 3
 		}
+
 		can_convert_from = {
 			module_category = large_plane_engine_type
 			convert_cost_ic = 30
@@ -206,6 +215,7 @@ equipment_modules = {
 			build_cost_ic = 38
 			fuel_consumption = 0.9
 		}
+
 
 		build_cost_resources = {
 			tungsten = 1
@@ -274,6 +284,7 @@ equipment_modules = {
 			build_cost_ic = 120
 			fuel_consumption = 2.3
 		}
+
 		build_cost_resources = {
 			tungsten = 2
 		}
@@ -295,6 +306,7 @@ equipment_modules = {
 			build_cost_ic = 160
 			fuel_consumption = 2.6
 		}
+
 		build_cost_resources = {
 			tungsten = 3
 		}

--- a/common/units/equipment/modules/00_r56_plane_modules.txt
+++ b/common/units/equipment/modules/00_r56_plane_modules.txt
@@ -35,6 +35,7 @@ equipment_modules = {
 		abbreviation = "aar2"
 		category = fighter_weapon
 		sfx = sfx_ui_sd_module_turret
+		parent = AA_rocket_rails
 		add_equipment_type = fighter
 
 		xp_cost = 4

--- a/common/units/equipment/modules/00_r56_plane_modules.txt
+++ b/common/units/equipment/modules/00_r56_plane_modules.txt
@@ -1,5 +1,8 @@
 equipment_modules = {
-
+	limit = {
+		has_dlc = "By Blood Alone"
+	}
+	
 	AA_rocket_rails = {
 		abbreviation = "aar"
 		category = fighter_weapon

--- a/common/units/equipment/modules/00_r56_plane_modules.txt
+++ b/common/units/equipment/modules/00_r56_plane_modules.txt
@@ -102,6 +102,11 @@ equipment_modules = {
 			fuel_consumption = 0.6
 		}
 
+		multiply_stats = {
+			air_agility = 0.1
+			air_range = -0.2
+		}
+
 		build_cost_resources = {
 			tungsten = 1
 		}
@@ -123,6 +128,10 @@ equipment_modules = {
 			thrust = 82
 			build_cost_ic = 50
 			fuel_consumption = 0.9
+		}
+		multiply_stats = {
+			air_agility = 0.1
+			air_range = -0.2
 		}
 
 		build_cost_resources = {
@@ -148,6 +157,11 @@ equipment_modules = {
 			fuel_consumption = 1.2
 		}
 
+		multiply_stats = {
+			air_agility = 0.1
+			air_range = -0.2
+		}
+
 		build_cost_resources = {
 			tungsten = 2
 		}
@@ -169,6 +183,11 @@ equipment_modules = {
 			thrust = 120
 			build_cost_ic = 100
 			fuel_consumption = 1.8
+		}
+
+		multiply_stats = {
+			air_agility = 0.1
+			air_range = -0.2
 		}
 
 		build_cost_resources = {
@@ -194,6 +213,11 @@ equipment_modules = {
 			fuel_consumption = 2.2
 		}
 
+		multiply_stats = {
+			air_agility = 0.1
+			air_range = -0.2
+		}
+
 		build_cost_resources = {
 			tungsten = 3
 		}
@@ -216,6 +240,9 @@ equipment_modules = {
 			fuel_consumption = 0.9
 		}
 
+		multiply_stats = {
+			air_agility = 0.15
+		}
 
 		build_cost_resources = {
 			tungsten = 1
@@ -240,6 +267,10 @@ equipment_modules = {
 			fuel_consumption = 1.2
 		}
 
+		multiply_stats = {
+			air_agility = 0.15
+		}
+
 		build_cost_resources = {
 			tungsten = 1
 		}
@@ -262,6 +293,11 @@ equipment_modules = {
 			build_cost_ic = 97
 			fuel_consumption = 1.6
 		}
+
+		multiply_stats = {
+			air_agility = 0.15
+		}
+
 		build_cost_resources = {
 			tungsten = 2
 		}
@@ -283,6 +319,10 @@ equipment_modules = {
 			thrust = 130
 			build_cost_ic = 120
 			fuel_consumption = 2.3
+		}
+
+		multiply_stats = {
+			air_agility = 0.15
 		}
 
 		build_cost_resources = {
@@ -307,9 +347,14 @@ equipment_modules = {
 			fuel_consumption = 2.6
 		}
 
+		multiply_stats = {
+			air_agility = 0.15
+		}
+
 		build_cost_resources = {
 			tungsten = 3
 		}
+
 		can_convert_from = {
 			module_category = large_plane_engine_type
 			convert_cost_ic = 30

--- a/common/units/equipment/modules/00_r56_plane_modules.txt
+++ b/common/units/equipment/modules/00_r56_plane_modules.txt
@@ -104,7 +104,7 @@ equipment_modules = {
 		}
 
 		multiply_stats = {
-			air_agility = 0.1
+			air_agility = 0.05
 			air_range = -0.2
 		}
 
@@ -131,7 +131,7 @@ equipment_modules = {
 			fuel_consumption = 0.9
 		}
 		multiply_stats = {
-			air_agility = 0.1
+			air_agility = 0.05
 			air_range = -0.2
 		}
 
@@ -159,7 +159,7 @@ equipment_modules = {
 		}
 
 		multiply_stats = {
-			air_agility = 0.1
+			air_agility = 0.05
 			air_range = -0.2
 		}
 
@@ -187,7 +187,7 @@ equipment_modules = {
 		}
 
 		multiply_stats = {
-			air_agility = 0.1
+			air_agility = 0.05
 			air_range = -0.2
 		}
 
@@ -215,7 +215,7 @@ equipment_modules = {
 		}
 
 		multiply_stats = {
-			air_agility = 0.1
+			air_agility = 0.05
 			air_range = -0.2
 		}
 
@@ -242,7 +242,7 @@ equipment_modules = {
 		}
 
 		multiply_stats = {
-			air_agility = 0.15
+			air_agility = 0.05
 		}
 
 		build_cost_resources = {
@@ -269,7 +269,7 @@ equipment_modules = {
 		}
 
 		multiply_stats = {
-			air_agility = 0.15
+			air_agility = 0.05
 		}
 
 		build_cost_resources = {
@@ -296,7 +296,7 @@ equipment_modules = {
 		}
 
 		multiply_stats = {
-			air_agility = 0.15
+			air_agility = 0.05
 		}
 
 		build_cost_resources = {
@@ -323,7 +323,7 @@ equipment_modules = {
 		}
 
 		multiply_stats = {
-			air_agility = 0.15
+			air_agility = 0.05
 		}
 
 		build_cost_resources = {
@@ -349,7 +349,7 @@ equipment_modules = {
 		}
 
 		multiply_stats = {
-			air_agility = 0.15
+			air_agility = 0.05
 		}
 
 		build_cost_resources = {

--- a/common/units/equipment/modules/00_ship_modules.txt
+++ b/common/units/equipment/modules/00_ship_modules.txt
@@ -1,5 +1,9 @@
 equipment_modules = {
 
+	limit = {
+			has_dlc = "Man the Guns" 
+		}
+
 
 #   ###  ##  #  # ###     ###   ##  ### ### ### ###  #   # 
 #    #  #    #  #  #      #  # #  #  #   #  #   #  #  # #  

--- a/common/units/equipment/modules/00_tank_r56_modules.txt
+++ b/common/units/equipment/modules/00_tank_r56_modules.txt
@@ -1,4 +1,7 @@
 equipment_modules = {
+	limit = {
+		has_dlc = "No Step Back" 
+	}
 
 	tank_front_plate_fixed_superstructure_turret = { #Only Soviets really used something like this. Added it to make super cheap tanks meme. Supposed to be bad stats becasuse IRL it was. 
 		abbreviation = "pfs"

--- a/common/units/equipment/plane_airframes.txt
+++ b/common/units/equipment/plane_airframes.txt
@@ -637,6 +637,17 @@ equipments = {
 					plane_special_module_defense_turret
 				}
 			}
+			special_type_slot_4 = {
+				required = no
+				allowed_module_categories = {
+					plane_special_module_small
+					plane_special_module_bomb_sights
+					plane_special_module_radio_navigation
+					plane_special_module_air_ground_radar
+					plane_special_module_air_air_radar
+					plane_special_module_defense_turret
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the following bugs:
* Players lacking dlc would still see some modules for designers. These have now been hidden.
* Players with "By Blood Alone" could previously build rocket interceptors, eventhough they  are supposed to use designer.
* Plane torpedoes can now be upgraded in designer by "upgrade"-button.
* Plane aa-rockets can now be upgraded in designer by "upgrade"-button.


This has been tested with and without dlc and looks good.

The following components have also been tweaked:
* Jet engines II & III: Now provide a small agility boost. Jet II also has a slight range debuff. This is to provide consistensy and a better transition from propeller to jet powered aircraft.
* Small modern airframe: Now has same number of special slots as the advanced airframe.