### PR TITLE
Carrier aircraft UI update

### DIFF
--- a/common/units/equipment/single_engine_airframe.txt
+++ b/common/units/equipment/single_engine_airframe.txt
@@ -1,314 +1,248 @@
 #####---------------------------------------------------------------------> Mod by Sig "GreatExperiment" Altre
-
-equipments = {
-
-	fighter_equipment = {
-		year = 1933
-
-		can_be_produced = {
-			NOT = {
-				has_idea = BUL_army_restrictions
-				has_idea = GER_treaty_of_versailles
-				has_idea = GER_treaty_of_versailles_2
-				has_idea = GER_treaty_of_versailles_3
-			}
-		}
-
-		is_archetype = yes
-		is_convertable = yes
-		picture = archetype_fighter_equipment
-		is_buildable = no
-		type = { fighter interceptor }
-		group_by = archetype
-		sprite = light_plane
-		air_map_icon_frame = 1
-
-		interface_category = interface_category_air
-
-		# Fighter
-		interface_overview_category_index = 1
-
-		upgrades = {
-			plane_gun_upgrade
-			plane_range_upgrade
-			plane_engine_upgrade
-			plane_reliability_upgrade
-		}
-
-		air_superiority = 1
-		reliability = 0.8
-
-        # Air vs Ground
-		air_ground_attack = 1.0
-		# Air vs Navy - low damage / high hit chance / easy to hurt
-		naval_strike_attack = 1
-		naval_strike_targetting = 10
-
-		#Space taken in convoy
-		lend_lease_cost = 8
-
-		build_cost_ic = 22
-		resources = {
-			aluminium = 2
-			rubber = 1
-		}
-
-		manpower = 20
-		fuel_consumption = 0.21
-	}
-
-	cv_fighter_equipment = {
-		year = 1933
-
-		can_be_produced = {
-			NOT = {
-				has_idea = BUL_army_restrictions
-			}
-		}
-
-		is_archetype = yes
-		is_convertable = yes
-		picture = archetype_fighter_equipment
-		is_buildable = no
-		type = { fighter interceptor }
-		group_by = archetype
-		sprite = light_plane
-		carrier_capable = yes
-		default_carrier_composition_weight = 1
-		air_map_icon_frame = 1
-
-		interface_category = interface_category_air
-
-		# Fighter
-		interface_overview_category_index = 1
-
-		upgrades = {
-			cv_plane_gun_upgrade
-			cv_plane_range_upgrade
-			plane_engine_upgrade
-			plane_reliability_upgrade
-		}
-
-		air_superiority = 1
-		reliability = 0.8
-
-		# Air vs Navy - low damage / high hit chance / easy to hurt
-		naval_strike_attack = 2
-		naval_strike_targetting = 10
-
-		#Space taken in convoy
-		lend_lease_cost = 8
-
-		build_cost_ic = 22
-		resources = {
-			aluminium = 2
-			rubber = 1
-		}
-
-		manpower = 20
-		fuel_consumption = 0.21
-	}
-
-	CAS_equipment = {
-		year = 1933
-
-		can_be_produced = {
-			NOT = {
-				has_idea = BUL_army_restrictions
-			}
-		}
-
-		is_archetype = yes
-		is_convertable = yes
-		picture = archetype_CAS_equipment
-		is_buildable = no
-		type = { cas fighter}
-		group_by = archetype
-		sprite = light_plane
-		air_map_icon_frame = 2
-
-		interface_category = interface_category_air
-
-		# CAS
-		interface_overview_category_index = 0
-
-		upgrades = {
-			plane_cas_upgrade
-			plane_range_upgrade
-			plane_engine_upgrade
-			plane_reliability_upgrade
-		}
-
-		air_superiority = 1
-		reliability = 0.8
-
-		# Air vs Ground
-		air_ground_attack = 1.0
-
-		# Air vs Navy - medium damage / high hit chance / medium to hurt
-		naval_strike_attack = 3
-		naval_strike_targetting = 10
-
-		build_cost_ic = 22
-		resources = {
-			aluminium = 2
-			rubber = 1
-		}
-
-		manpower = 20
-		fuel_consumption = 0.26
-	}
-
-	cv_CAS_equipment = {
-		year = 1933
-
-		can_be_produced = {
-			NOT = {
-				has_idea = BUL_army_restrictions
-			}
-		}
-
-		is_archetype = yes
-		is_convertable = yes
-		picture = archetype_CAS_equipment
-		is_buildable = no
-		type = { cas fighter}
-		group_by = archetype
-		sprite = light_plane
-		carrier_capable = yes
-		air_map_icon_frame = 2
-
-		interface_category = interface_category_air
-
-		# CAS
-		interface_overview_category_index = 0
-
-		upgrades = {
-			plane_cas_upgrade
-			cv_plane_range_upgrade
-			plane_engine_upgrade
-			plane_reliability_upgrade
-		}
-
-		air_superiority = 1
-		reliability = 0.8
-
-		# Air vs Ground
-		air_ground_attack = 1.0
-
-		# Air vs Navy - medium damage / high hit chance / medium to hurt
-		naval_strike_attack = 4
-		naval_strike_targetting = 10
-
-		build_cost_ic = 22
-		resources = {
-			aluminium = 2
-			rubber = 1
-		}
-
-		manpower = 20
-		fuel_consumption = 0.26
-	}
-
-	nav_bomber_equipment = {
-		year = 1933
-
-		can_be_produced = {
-			NOT = {
-				has_idea = BUL_army_restrictions
-			}
-		}
-
-		is_archetype = yes
-		is_convertable = yes
-		picture = archetype_heavy_fighter_equipment
-		carrier_capable = yes
-		is_buildable = no
-		type = { naval_bomber }
-		group_by = archetype
-		sprite = light_plane
-		air_map_icon_frame = 3
-		default_carrier_composition_weight = 1
-
-		interface_category = interface_category_air
-
-		# Naval bomber
-		interface_overview_category_index = 2
-
-		upgrades = {
-			plane_naval_upgrade
-			plane_range_upgrade
-			plane_engine_upgrade
-			plane_reliability_upgrade
-		}
-
-		air_superiority = 1
-		reliability = 0.8
-
-		# Air vs Navy - high damage / medium hit chance / easy to hurt
-		naval_strike_attack = 15
-		naval_strike_targetting = 7.5
-
-		build_cost_ic = 26
-		resources = {
-			aluminium = 2
-			rubber = 1
-		}
-
-		manpower = 20
-		fuel_consumption = 0.28
-	}
-
-	jet_fighter_equipment = {
-		year = 1933
-
-		can_be_produced = {
-			NOT = {
-				has_idea = BUL_army_restrictions
-			}
-		}
-
-		is_archetype = yes
-		is_convertable = yes
-		picture = archetype_fighter_equipment
-		is_buildable = no
-		type = fighter
-		group_by = archetype
-		sprite = jet_plane
-		air_map_icon_frame = 4
-
-		interface_category = interface_category_air
-
-		# Fighter
-		interface_overview_category_index = 1
-
-		upgrades = {
-			plane_gun_upgrade
-			plane_range_upgrade
-			plane_engine_upgrade
-			plane_reliability_upgrade
-		}
-
-		air_superiority = 1
-		reliability = 0.8
-
-        # Air vs Ground
-		# Air vs Navy - low damage / high hit chance / easy to hurt
-		naval_strike_attack = 5
-		naval_strike_targetting = 10
-
-		build_cost_ic = 30
-		resources = {
-			aluminium = 2
-			tungsten = 3
-			rubber = 1
-		}
-
-		manpower = 40
-		fuel_consumption = 0.42
-	}
-
-
+#	equipments = {
+#		fighter_equipment = {
+#		year = 1933
+#			can_be_produced = {
+#			NOT = {
+#				has_idea = BUL_army_restrictions
+#				has_idea = GER_treaty_of_versailles
+#				has_idea = GER_treaty_of_versailles_2
+#				has_idea = GER_treaty_of_versailles_3
+#			}
+#		}
+#			is_archetype = yes
+#		is_convertable = yes
+#		picture = archetype_fighter_equipment
+#		is_buildable = no
+#		type = { fighter interceptor }
+#		group_by = archetype
+#		sprite = light_plane
+#		air_map_icon_frame = 1
+#			interface_category = interface_category_air
+#			# Fighter
+#		interface_overview_category_index = 1
+#			upgrades = {
+#			plane_gun_upgrade
+#			plane_range_upgrade
+#			plane_engine_upgrade
+#			plane_reliability_upgrade
+#		}
+#			air_superiority = 1
+#		reliability = 0.8
+#	        # Air vs Ground
+#		air_ground_attack = 1.0
+#		# Air vs Navy - low damage / high hit chance / easy to hurt
+#		naval_strike_attack = 1
+#		naval_strike_targetting = 10
+#			#Space taken in convoy
+#		lend_lease_cost = 8
+#			build_cost_ic = 22
+#		resources = {
+#			aluminium = 2
+#			rubber = 1
+#		}
+#			manpower = 20
+#		fuel_consumption = 0.21
+#	}
+#		cv_fighter_equipment = {
+#		year = 1933
+#			can_be_produced = {
+#			NOT = {
+#				has_idea = BUL_army_restrictions
+#			}
+#		}
+#			is_archetype = yes
+#		is_convertable = yes
+#		picture = archetype_fighter_equipment
+#		is_buildable = no
+#		type = { fighter interceptor }
+#		group_by = archetype
+#		sprite = light_plane
+#		carrier_capable = yes
+#		default_carrier_composition_weight = 1
+#		air_map_icon_frame = 1
+#			interface_category = interface_category_air
+#			# Fighter
+#		interface_overview_category_index = 1
+#			upgrades = {
+#			cv_plane_gun_upgrade
+#			cv_plane_range_upgrade
+#			plane_engine_upgrade
+#			plane_reliability_upgrade
+#		}
+#			air_superiority = 1
+#		reliability = 0.8
+#			# Air vs Navy - low damage / high hit chance / easy to hurt
+#		naval_strike_attack = 2
+#		naval_strike_targetting = 10
+#			#Space taken in convoy
+#		lend_lease_cost = 8
+#			build_cost_ic = 22
+#		resources = {
+#			aluminium = 2
+#			rubber = 1
+#		}
+#			manpower = 20
+#		fuel_consumption = 0.21
+#	}
+#		CAS_equipment = {
+#		year = 1933
+#			can_be_produced = {
+#			NOT = {
+#				has_idea = BUL_army_restrictions
+#			}
+#		}
+#			is_archetype = yes
+#		is_convertable = yes
+#		picture = archetype_CAS_equipment
+#		is_buildable = no
+#		type = { cas fighter}
+#		group_by = archetype
+#		sprite = light_plane
+#		air_map_icon_frame = 2
+#			interface_category = interface_category_air
+#			# CAS
+#		interface_overview_category_index = 0
+#			upgrades = {
+#			plane_cas_upgrade
+#			plane_range_upgrade
+#			plane_engine_upgrade
+#			plane_reliability_upgrade
+#		}
+#			air_superiority = 1
+#		reliability = 0.8
+#			# Air vs Ground
+#		air_ground_attack = 1.0
+#			# Air vs Navy - medium damage / high hit chance / medium to hurt
+#		naval_strike_attack = 3
+#		naval_strike_targetting = 10
+#			build_cost_ic = 22
+#		resources = {
+#			aluminium = 2
+#			rubber = 1
+#		}
+#			manpower = 20
+#		fuel_consumption = 0.26
+#	}
+#		cv_CAS_equipment = {
+#		year = 1933
+#			can_be_produced = {
+#			NOT = {
+#				has_idea = BUL_army_restrictions
+#			}
+#		}
+#			is_archetype = yes
+#		is_convertable = yes
+#		picture = archetype_CAS_equipment
+#		is_buildable = no
+#		type = { cas fighter}
+#		group_by = archetype
+#		sprite = light_plane
+#		carrier_capable = yes
+#		air_map_icon_frame = 2
+#			interface_category = interface_category_air
+#			# CAS
+#		interface_overview_category_index = 0
+#			upgrades = {
+#			plane_cas_upgrade
+#			cv_plane_range_upgrade
+#			plane_engine_upgrade
+#			plane_reliability_upgrade
+#		}
+#			air_superiority = 1
+#		reliability = 0.8
+#			# Air vs Ground
+#		air_ground_attack = 1.0
+#			# Air vs Navy - medium damage / high hit chance / medium to hurt
+#		naval_strike_attack = 4
+#		naval_strike_targetting = 10
+#			build_cost_ic = 22
+#		resources = {
+#			aluminium = 2
+#			rubber = 1
+#		}
+#			manpower = 20
+#		fuel_consumption = 0.26
+#	}
+#		nav_bomber_equipment = {
+#		year = 1933
+#			can_be_produced = {
+#			NOT = {
+#				has_idea = BUL_army_restrictions
+#			}
+#		}
+#			is_archetype = yes
+#		is_convertable = yes
+#		picture = archetype_heavy_fighter_equipment
+#		carrier_capable = yes
+#		is_buildable = no
+#		type = { naval_bomber }
+#		group_by = archetype
+#		sprite = light_plane
+#		air_map_icon_frame = 3
+#		default_carrier_composition_weight = 1
+#			interface_category = interface_category_air
+#			# Naval bomber
+#		interface_overview_category_index = 2
+#			upgrades = {
+#			plane_naval_upgrade
+#			plane_range_upgrade
+#			plane_engine_upgrade
+#			plane_reliability_upgrade
+#		}
+#			air_superiority = 1
+#		reliability = 0.8
+#			# Air vs Navy - high damage / medium hit chance / easy to hurt
+#		naval_strike_attack = 15
+#		naval_strike_targetting = 7.5
+#			build_cost_ic = 26
+#		resources = {
+#			aluminium = 2
+#			rubber = 1
+#		}
+#			manpower = 20
+#		fuel_consumption = 0.28
+#	}
+#		jet_fighter_equipment = {
+#		year = 1933
+#			can_be_produced = {
+#			NOT = {
+#				has_idea = BUL_army_restrictions
+#			}
+#		}
+#			is_archetype = yes
+#		is_convertable = yes
+#		picture = archetype_fighter_equipment
+#		is_buildable = no
+#		type = fighter
+#		group_by = archetype
+#		sprite = jet_plane
+#		air_map_icon_frame = 4
+#			interface_category = interface_category_air
+#			# Fighter
+#		interface_overview_category_index = 1
+#			upgrades = {
+#			plane_gun_upgrade
+#			plane_range_upgrade
+#			plane_engine_upgrade
+#			plane_reliability_upgrade
+#		}
+#			air_superiority = 1
+#		reliability = 0.8
+#	        # Air vs Ground
+#		# Air vs Navy - low damage / high hit chance / easy to hurt
+#		naval_strike_attack = 5
+#		naval_strike_targetting = 10
+#			build_cost_ic = 30
+#		resources = {
+#			aluminium = 2
+#			tungsten = 3
+#			rubber = 1
+#		}
+#			manpower = 40
+#		fuel_consumption = 0.42
+#	}
+#	
 	# Early Fighter
 #	fighter_equipment_0 = {
 #		year = 1933
@@ -1245,6 +1179,6 @@ equipments = {
 #		build_cost_ic = 31.2 # cv_version costs 20% more of base archetype
 #	}
 
-}
+#}
 
 #####---------------------------------------------------------------------> End

--- a/localisation/english/plane_designer_l_english.yml
+++ b/localisation/english/plane_designer_l_english.yml
@@ -358,7 +358,7 @@
  cv_small_plane_cas_airframe_short:0 "$cv_CAS_equipment_short$"
  cv_small_plane_naval_bomber_airframe:1 "$cv_nav_bomber_equipment$"
  cv_small_plane_naval_bomber_airframe_short:0 "$cv_nav_bomber_equipment_short$"
- cv_small_plane_suicide_airframe:2 "Carrier Suicide Craft"
+ cv_small_plane_suicide_airframe:2 "CV Suicide Craft"
  cv_small_plane_suicide_airframe_short:0 "CV Suicide Craft"
  cv_small_plane_airframe_desc:0 "Equipped with an arrestor hook and a strengthened landing gear, this small airframe is capable of operating from carriers."
  cv_small_plane_cas_airframe_desc:0 "$cv_small_plane_airframe_desc$"

--- a/localisation/english/replace/r56e_equip_aircraft_l_english.yml
+++ b/localisation/english/replace/r56e_equip_aircraft_l_english.yml
@@ -78,7 +78,7 @@ l_english:
  CAS_equipment_3_desc:0 "The ever-increasing capability of target AA and enemy interceptors requires further evolution of our CAS aircraft. The new design incorporates increased engine power, airframe improvements for increased diving capability and protection, and even greater payloads."
  
 #-> Carrier-based dive bombers <><>
- cv_cas:1 "Close Air Support"
+ cv_cas:1 "Carrier Close Air Support"
  cv_CAS_equipment: "CV Close Air Support"
  cv_CAS_equipment_short:0 "CV Close Air Support"
  cv_CAS_equipment:0 "CV Close Air Support"
@@ -127,7 +127,7 @@ l_english:
  
 #-> Carrier-based light fighters <><>
  cv_fighter:0 "Carrier Fighter"
- cv_fighter_equipment:0 "Carrier Fighter"
+ cv_fighter_equipment:0 "CV Fighter"
  cv_fighter_equipment_short:0 "CV Fighter" 
  cv_fighter_equipment_desc:0 "Fighters are fast and nimble and can do many jobs. Everything from fighting for air superiority, protecting your bombers, and intercepting the enemy's bombers."
  cv_fighter_equipment_0:0 "Carrier Fighter '30"
@@ -161,7 +161,7 @@ l_english:
  nav_bomber_equipment_3_desc:0 "All-metal designs and powerful airbrakes allow for more complex naval aeronautics. However, the planes of the future will demand a larger crew to operate these advanced systems."
  
 #-> Carrier-based Naval bombers <><>
- cv_nav_bomber:0 "Naval Bomber"
+ cv_nav_bomber:0 "Carrier Naval Bomber"
  cv_nav_bomber_equipment:0 "Carrier Naval Bomber"
  cv_nav_bomber_equipment:1 "CV Naval Bomber"
  cv_nav_bomber_equipment_short:0 "CV Naval Bomber"
@@ -312,7 +312,7 @@ l_english:
  jet_fighter_equipment_x_desc:0 "An advanced jet fighter built with the latest in technology."
  
 #-> Carrier-based jet fighters <><>
- cv_jet_fighter:0 "CV Fighter"
+ cv_jet_fighter:0 "Carrier Jet Fighter"
  cv_jet_fighter_equipment:0 "CV Jet Fighter"
  cv_jet_fighter_equipment_1:0 "Carrier Jet Fighter '45"
  cv_jet_fighter_equipment_1_short:0 "Jet Fighter CV '45"


### PR DESCRIPTION
When building aircraft carriers and setting its default aircraft complement, one could see extra airframes (that are unbuildable). This update removes these superfluous items.

This update also standardizes the names for CV aircraft in the UI mentioned above along with the "quick-deploy" window.