### PR TITLE
Make AA rocket rail only heavy fighters work

### DIFF
--- a/common/units/equipment/modules/00_r56_plane_modules.txt
+++ b/common/units/equipment/modules/00_r56_plane_modules.txt
@@ -7,7 +7,7 @@ equipment_modules = {
 		abbreviation = "aar"
 		category = fighter_weapon
 		sfx = sfx_ui_sd_module_turret
-		add_equipment_type = fighter
+		add_equipment_type = { fighter heavy_fighter }
 
 		xp_cost = 2
 		add_stats = {
@@ -36,7 +36,7 @@ equipment_modules = {
 		category = fighter_weapon
 		sfx = sfx_ui_sd_module_turret
 		parent = AA_rocket_rails
-		add_equipment_type = fighter
+		add_equipment_type = { fighter heavy_fighter }
 
 		xp_cost = 4
 		add_stats = { #bad against agile figther but very good against bombers


### PR DESCRIPTION
Previously if you tried to make an AA rocket rail only heavy fighter, it just wouldn't work because the game couldn't recognize the equipment type.