### PR TITLE
Sweden: new naval name lists

### DIFF
--- a/common/units/names/00_names.txt
+++ b/common/units/names/00_names.txt
@@ -7727,64 +7727,6 @@ URG = {
 }
 
 SWE = {
-	submarine = {
-		prefix = "HMS"
-		generic = { "Ubåt" }
-		unique = {
-			"Hajen" "Sälen" "Valrossen" "Bävern" "Illern" "Uttern" "Valen" "Draken" "Gripen" "Ulven" "Delfinen" "Nordkaparen" "Springaren"
-			"Sjölejonet" "Sjöbjörnen" "Sjöhunden" "Svärdfisken" "Tumlaren" "Dykaren" "Sjöhästen" "Sjöormen" "Sjöborren" 
-			"Neptun" "Najad" "Näcken" "U1" "U2" "U3" "U4" "U5" "U6" "U7" "U8" "U9" "Vargen" "Forellen" "Aborren" "Siken" "Gäddan" "Laxen" "Makrillen" 
-		}
-	}
-	destroyer = {
-		prefix = "HMS"
-		generic = { "Jagare" }
-		unique = {
-			"Örnen" "Jacob Bagge" "Klas Horn" "Klas Uggla" "Ehrensköld" "Nordenskjöld" "Göteborg" "Plisander" "Puke" "Romulus" "Remus" "Halland" 
-			"Småland" "Östergötland" "Södermanland" "Gästrikland" "Hälsingland" "Öland" "Uppland" "Visby" "Sundsvall" "Hälsingborg" "Kalmar" 
-			"Stockholm" "Malmö" "Karlskrona" "Gävle" "Wrangel" "Wachtmeister" "Mode" "Magne" "Mjölner" "Munin" "Ragnar" "Sigurd" "Vidar" 
-			"Hugin" "Wale" 
-		}
-	}
-	light_cruiser = {
-		prefix = "HMS"
-		generic = { "Lätt KRyśsare" }
-		unique = {
-			"Gotland" "Fylgia" "Klas Horn" "Klas Uggla" "Psilander" "Göta Lejon" "Tre Kronor" "Klas Fleming"
-			"Kalmar" "Västervik" "Gävle" "Malmö" "Halmstad" "Karlskrona" "Sundsvall" "Luleå" "Umeå" "Härnösand" "Hudiksvall" 
-			"Uddevalla" "Helsingborg" "Varberg" "Norrköping" "Söderköping" "Visby" "Älvsnabben"
-		}
-	}
-	heavy_cruiser = {
-		prefix = "HMS"
-		generic = { "Tung KRyśsare" }
-		unique = {
-			"Dristigheten" "Sverige" "Drottning Victoria" "Gustav V" "Äran" "Tapperheten" "Wasa" "Manligheten" "Oscar II" "Klas Fleming" 
-			"Hans Wachtmeister" "Tre Kronor" "Älvsnabben" "Starkodder" "Styrbiörn" "Gotland" "Svealand" "Götaland" "Norrland" 
-			"Oden" "Thor" "Niord" "Svea" "Göta" "Thule" 
-		}
-	}
-	battle_cruiser = {
-		prefix = "HMS"
-		generic = { "Stridsskepp" }
-		unique = {
-			"Gustav II Adolf" "Karl XII" "Karl XI" "Gustav III" "Gustav Vasa" 
-		}
-	}
-	battleship = {
-		prefix = "HMS"
-		generic = { "Slagskepp" }
-		unique = {
-			"Stockholm" "Karl XIV Johann" "Gustav II Adolf" "Karl XII" "Karl XI" "Gustav III" 
-		}
-	}
-	carrier = {
-		prefix = "HMS"
-		generic = { "Hangarfartyg" }
-		unique = {
-			"Kronan" "Riksäpplet" "Spiran" "Dristigheten" "Jacob Bagge" "Gotland" 
-		}
-	}
 	air_wing_names_template = AIR_WING_NAME_SWE_FALLBACK
 
 	#Air wings can only be named through archetype

--- a/common/units/names_ships/SWE_ship_names.txt
+++ b/common/units/names_ships/SWE_ship_names.txt
@@ -128,3 +128,107 @@ SWE_SS_HISTORICAL = {
 	}
 }
 
+### THEME: SWEDISH STATES ###
+SWE_STATES = {
+	name = NAME_THEME_STATES
+
+	for_countries = { SWE }
+
+	type = ship
+
+	prefix = "HMS "
+	fallback_name = "HM Skepp %d"
+
+	unique = {
+		"Södermanland" "Dalsland" "Norrbotten" "Blekinge" "Öland" "Västmanland" "Medelpad" "Dalarna" "Östergötland" "Lappland" "Gotland"
+        "Hälsingland" "Västerbotten" "Värmland" "Halland" "Härjedalen" "Västergötland" "Närke" "Småland" "Bohuslän" "Uppland" "Jämtland"
+        "Ångermanland" "Gästrikland"
+	}
+}
+
+## THEME: SWEDISH CITIES ###
+SWE_CITIES = {
+	name = NAME_THEME_CITIES
+
+	for_countries = { SWE }
+
+	type = ship
+
+	prefix = "HMS "
+	fallback_name = "HM Skepp %d"
+
+	unique = {
+		"Helsingborg" "Gävle" "Södertälje" "Huddinge" "Västerås" "Malmö" "Halmstad" "Norrköping" "Borås" "Sundsvall" "Stockholm"
+        "Uppsala" "Eskilstuna" "Umeå" "Göteborg" "Örebro" "Lund" "Linköping" "Jönköping" "Nacka" "Luleå" "Mölndal" "Växjö" "Kungsholmen"
+        "Täby" "Ängelholm" "Haninge" "Sundbyberg" "Sollentuna" "Östersund" "Karlstad" "Solna" "Bromma" "Karlskrona" "Borlänge"
+        "Trollhättan" "Lidingö" "Trelleborg" "Uddevalla" "Kristianstad" "Varberg" "Vallentuna" "Skellefteå" "Tumba" "Ystad" "Örnsköldsvik"
+        "Falun" "Skövde" "Upplands Väsby" "Kalmar" "Landskrona" "Motala" "Nyköping" "Värnamo" "Jakobsberg" "Partille" "Alingsås"
+        "Kristinehamn" "Mölnlycke" "Falköping" "Sjöbo" "Hässleholm" "Falkenberg" "Västervik" "Nässjö" "Härnösand" "Oskarshamn" "Kiruna"
+        "Björlanda" "Boo" "Gustavsberg" "Mariestad" "Boden" "Råsunda" "Enköping" "Vänersborg" "Märsta" "Floda" "Visby" "Båstad" "Hudiksvall"
+        "Staffanstorp" "Karlskoga" "Eslöv" "Grums" "Åkersberga" "Piteå" "Årstad" "Sjövik" "Lidköping" "Kungälv" "Sandviken" "Norrtälje"
+        "Kumla" "Kungsbacka" "Katrineholm" "Karlshamn" "Lerum" "Huskvarna" "Köping"
+	}
+}
+
+
+### THEME: HISTORICAL KINGS ###
+SWE_LEADERS = {
+	name = NAME_THEME_KINGS
+
+	for_countries = { SWE }
+
+	type = ship
+
+	prefix = "HMS "
+	fallback_name = "HM Skepp %d"
+
+	unique = {
+		"Johan III" "Karl X Gustav" "Gustav IV Adolf" "Sigismund III" "Gustaf VI Adolf" "Karl XII" "Oscar V" "Gustav Vasa" "Fredrik I"
+		"Karl XV" "Erik XIV" "Karl XIII" "Karl XI" "Gustav III" "Oscar I" "Karl XIV Johan" "Gustav II Adolf" "Karl IX" 
+	}
+}
+
+## THEME: BIRDS ###
+SWE_BIRDS = {
+	name = NAME_THEME_BIRDS
+
+	for_countries = { SWE }
+
+	type = ship
+
+	prefix = "HMS "
+	fallback_name = "HM Skepp %d"
+
+	unique = {
+		"Lunnefågeln" "Gräsanden" "Gulhämplingen" "Salskraken" "Spetsbergsgåsen" "Kustsnäppan" "Kornknarren" "Svarthakedoppingen"
+        "Rördromen" "Storskarven" "Gråsiskan" "Jordugglan" "Kustpiparen" "Snösparven" "Kajan" "Svarttärnan" "Hussvalan"
+        "Fjällripan" "Järpen" "Sandlöparen" "Doppingen" "Fjällabben" "Tamduvan" "Stenfalken" "Blåhaken" "Tajgasångaren" "Skräntärnan"
+        "Spillkråkan" "Bofinken" "Pärlugglan" "Gråtruten" "Grönsångaren" "Trastsångaren" "Fjällpiparen" "Morkullan" "Orren" "Årtan"
+        "Gräshoppsångaren" "Fjällgåsen" "Domherren" "Smådoppingen" "Drillsnäppan" "Sånglärkan" "Forsärlan" "Korpen" "Tärnmåsen"
+        "Rödspoven" "Brushanen" "Törnskatan" "Blåkråkan" "Tornseglaren" "Sävsparven" "Berglärkan" "Havstruten" "Sjöorren" "Nilgåsen"
+        "Järnsparven" "Sillgrisslan" "Dubbeltrasten" "Enkelbeckasinen" "Sädgåsen" "Storspoven" "Gransångaren" "Dvärgbeckasinen"
+        "Smålomen" "Gluttsnäppan" "Myrspoven" "Silltruten" "Fjällugglan" "Nordsångaren" "Nattskärran" "Kungsfågelsångaren" "Tornfalken"
+        "Småspoven" "Härfågeln" "Gulärlan" "Knipan" "Härmsångaren" "Småsnäppan" "Svartmesen" "Fisktärnan" "Duvhöken" "Lappugglan" "Rörsångaren"
+        "Vattenrallen" "Rosenstaren" "Stjärtanden" "Grönfinken" "Skarven" "Toppskarven" "Sommargyllingen" "Skedanden" "Svarthättan" "Roskarln"
+        "Skogsduvan" "Sångsvanen" "Grönsiskan" "Talltitan" "Rostanden" "Skärfläckan"
+	}
+}
+
+### THEME: FISH ###
+SWE_FISH = {
+	name = NAME_THEME_FISH
+
+	for_countries = { SWE }
+
+	type = ship
+
+	prefix = "HMS "
+	fallback_name = "HM Skepp %d"
+
+	unique = {
+		"Kungsfisken" "Hälleflundran" "Sjuryggen" "Ålen" "Torsken" "Fjärsingen" "Hellefisken" "Stillahavsblekan" "Horngäddan" "Rödtungan"
+        "Långan" "Gäddan" "Kummeln" "Siken" "Aborren" "Marulken" "Öringen" "Koljan" "Blåmusslan" "Rödspättan" "Havskatten" "Rödingen"
+        "Sillen" "Sandskäddan" "Braxen" "Strömmingen" "Sillhajen" "Rockan" "Lakeen" "Hokin" "Tonfisken" "Berggyltaren" "Lubben" "Sejen"
+        "Makrillen" "Sjötungan" "Belknapen" "Vitlingen" "Bergtungan" "Gösen" "Laxen" "Pigghajen" "Karpen" "Knoten" "Piggvaren"
+	}
+}

--- a/common/units/names_ships/SWE_ship_names.txt
+++ b/common/units/names_ships/SWE_ship_names.txt
@@ -1,0 +1,130 @@
+##### SWEDEN NAME LISTS #####
+### REGULAR DESTROYER NAMES###
+SWE_DD_HISTORICAL = {
+	name = NAME_THEME_HISTORICAL_DESTROYERS
+
+	for_countries = { SWE }
+
+	type = ship
+	ship_types = { ship_hull_light destroyer }
+
+	prefix = "HMS "
+	fallback_name = "HM Jagare J%d"
+
+	unique = {
+        "Örnen" "Jacob Bagge" "Klas Horn" "Klas Uggla" "Ehrensköld" "Nordenskjöld" "Göteborg" "Plisander" "Puke" "Romulus" "Remus" "Halland"
+        "Småland" "Östergötland" "Södermanland" "Gästrikland" "Hälsingland" "Öland" "Uppland" "Visby" "Sundsvall" "Hälsingborg" "Kalmar"
+        "Stockholm" "Malmö" "Karlskrona" "Gävle" "Wrangel" "Wachtmeister" "Mode" "Magne" "Mjölner" "Munin" "Ragnar" "Sigurd" "Vidar"
+        "Hugin" "Wale"
+    }
+}
+
+
+### LIGHT CRUISER NAMES ###
+SWE_CL_HISTORICAL = {
+	name = NAME_THEME_HISTORICAL_CL
+
+	for_countries = { SWE }
+
+	type = ship
+	ship_types = { ship_hull_cruiser light_cruiser }
+
+	prefix = "HMS "
+	fallback_name = "HM Lätt kryssare %d"
+
+	unique = {
+        "Gotland" "Fylgia" "Klas Horn" "Klas Uggla" "Psilander" "Göta Lejon" "Tre Kronor" "Klas Fleming"
+        "Kalmar" "Västervik" "Gävle" "Malmö" "Halmstad" "Karlskrona" "Sundsvall" "Luleå" "Umeå" "Härnösand" "Hudiksvall"
+        "Uddevalla" "Helsingborg" "Varberg" "Norrköping" "Söderköping" "Visby" "Älvsnabben"
+    }
+}
+
+### HEAVY CRUISER NAMES ###
+SWE_CA_HISTORICAL = {
+	name = NAME_THEME_HISTORICAL_CA
+
+	for_countries = { SWE }
+
+	type = ship
+	ship_types = { ship_hull_cruiser heavy_cruiser }
+
+	prefix = "HMS "
+	fallback_name = "HM Tung kryssare %d"
+
+	unique = {
+        "Dristigheten" "Sverige" "Drottning Victoria" "Gustav V" "Äran" "Tapperheten" "Wasa" "Manligheten" "Oscar II" "Klas Fleming"
+        "Hans Wachtmeister" "Tre Kronor" "Älvsnabben" "Starkodder" "Styrbiörn" "Gotland" "Svealand" "Götaland" "Norrland"
+        "Oden" "Thor" "Niord" "Svea" "Göta" "Thule"
+    }
+}
+
+### BATTLESHIP NAMES ###
+SWE_BB_HISTORICAL = {
+	name = NAME_THEME_HISTORICAL_BB
+
+	for_countries = { SWE }
+
+	type = ship
+	ship_types = { ship_hull_heavy battleship }
+
+	prefix = "HMS "
+	fallback_name = "HM Slagskepp %d"
+
+	unique = {
+		"Stockholm" "Karl XIV Johan" "Gustav II Adolf" "Karl XII" "Karl XI" "Gustav III"
+	}
+}
+
+### BATTLECRUISER NAMES ###
+SWE_BC_HISTORICAL = {
+	name = NAME_THEME_HISTORICAL_BC
+
+	for_countries = { SWE }
+
+	type = ship
+	ship_types = { ship_hull_heavy battle_cruiser }
+
+	prefix = "HMS "
+	fallback_name = "HM Slagkryssare BC-%d"
+
+	unique = {
+		"Gustav II Adolf" "Karl XII" "Karl XI" "Gustav III" "Gustav Vasa"
+	}
+}
+
+### AIRCRAFT CARRIER NAMES ###
+SWE_CV_HISTORICAL = {
+	name = NAME_THEME_HISTORICAL_CARRIERS
+
+	for_countries = { SWE }
+
+	type = ship
+	ship_types = { ship_hull_carrier carrier }
+
+	prefix = "HMS "
+	fallback_name = "HM Hangarfartyg %d"
+
+	unique = {
+		"Kronan" "Riksäpplet" "Spiran" "Dristigheten" "Jacob Bagge" "Gotland"
+	}
+}
+
+### SUBMARINES ###
+SWE_SS_HISTORICAL = {
+	name = NAME_THEME_HISTORICAL_SUBMARINES
+
+	for_countries = { SWE }
+
+	type = ship
+	ship_types = { ship_hull_submarine submarine }
+
+	prefix = "HMS "
+	fallback_name = "HM Ubåt U%d"
+
+	unique = {
+		"Hajen" "Sälen" "Valrossen" "Bävern" "Illern" "Uttern" "Valen" "Draken" "Gripen" "Ulven" "Delfinen" "Nordkaparen" "Springaren"
+		"Sjölejonet" "Sjöbjörnen" "Sjöhunden" "Svärdfisken" "Tumlaren" "Dykaren" "Sjöhästen" "Sjöormen" "Sjöborren"
+		"Neptun" "Najad" "Näcken" "Vargen" "Forellen" "Aborren" "Siken" "Gäddan" "Laxen" "Makrillen"
+	}
+}
+


### PR DESCRIPTION
Split from PR#2858

This PR adds new name lists for Sweden with the following themes:
* States/regions
* Cities
* Historical kings
* Birds
* Fish

This also fixes the misspelling of 'Cruiser' in the fallback shipnames.