### PR TITLE
Remove channel islands - Normandy crossing

### DIFF
--- a/map/adjacencies.csv
+++ b/map/adjacencies.csv
@@ -298,5 +298,4 @@ From;To;Type;Through;start_x;start_y;stop_x;stop_y;adjacency_rule_name;Comment
 8282;843;sea;9417;11559;6758;9417;757;VOLGA_DON_CANAL;Volga-Don
 2196;13237;sea;5394;-1;-1;-1;-1;;Tanganyika-Zanzibar
 8051;13306;sea;2691;-1;-1;-1;-1;;Qatar-Bahrain
-6449;13425;sea;2871;-1;-1;-1;-1;;Normandy-Jersey
 -1;-1;;-1;-1;-1;-1;-1;-1


### PR DESCRIPTION
Removed the Channel Islands - Normany crossing as a temporary stopgap to stop UK from being able to land trade and dday not occuring, while not breaking saves in the meanwhile