### PR TITLE
Air tech year alignment

### DIFF
--- a/common/ai_equipment/USA_planes.txt
+++ b/common/ai_equipment/USA_planes.txt
@@ -79,7 +79,7 @@ USA_fighter = {
 		priority = {
 			factor = 0 #100
 			modifier = {
-				has_tech = advanced_small_airframe 
+				has_tech = advanced_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
 		}
@@ -1707,7 +1707,7 @@ USA_maritime_patrol = {
 						air_ground_radar_2
 						air_ground_radar_1
 						recon_camera
-						hmg_defense_turret_2x 
+						hmg_defense_turret_2x
 					}
 				}
 				special_type_slot_3 = fuel_tanks_large

--- a/common/ai_equipment/USA_planes.txt
+++ b/common/ai_equipment/USA_planes.txt
@@ -20,7 +20,7 @@ USA_fighter = {
 	great_war_fighter_default = {
 		priority = {
 			factor = 0 #1
-			modifier = {
+			modifier = { 
 				has_tech = basic_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -34,7 +34,7 @@ USA_fighter = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_1_1x
 				special_type_slot_1 = empty
-				special_type_slot_2 = empty
+				special_type_slot_2 = empty	
 			}
 		}
 
@@ -47,7 +47,7 @@ USA_fighter = {
 	basic_fighter_default = {
 		priority = {
 			factor = 0 #100
-			modifier = {
+			modifier = { 
 				has_tech = improved_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -61,7 +61,7 @@ USA_fighter = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_2_1x
 				special_type_slot_1 = empty
-				special_type_slot_2 = empty
+				special_type_slot_2 = empty	
 			}
 		}
 
@@ -78,8 +78,8 @@ USA_fighter = {
 	improved_fighter_default = {
 		priority = {
 			factor = 0 #100
-			modifier = {
-				has_tech = advanced_small_airframe
+			modifier = { 
+				has_tech = advanced_small_airframe 
 				factor = 0 #0 #let's not waste XP here
 			}
 		}
@@ -95,6 +95,7 @@ USA_fighter = {
 				special_type_slot_1 = drop_tanks
 				special_type_slot_2 = fuel_tanks_small	
 				special_type_slot_3 = empty	
+
 			}
 		}
 
@@ -108,7 +109,7 @@ USA_fighter = {
 	advanced_fighter_default = {
 		priority = {
 			factor = 0 #100
-			modifier = {
+			modifier = { 
 				has_tech = modern_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -125,22 +126,21 @@ USA_fighter = {
 				engine_type_slot = engine_4_1x
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = drop_tanks
-				special_type_slot_3 = fuel_tanks_small
+				special_type_slot_3 = fuel_tanks_small	
 			}
 		}
 
-		allowed_modules = {
+		allowed_modules = { 
 			drop_tanks
 			heavy_mg_4x
 			engine_4_1x
 			armor_plate_small
 		}
 	}
-
 	jet_fighter_default = {
 		priority = {
 			factor = 0 #600
-			#modifier = {
+			#modifier = { 
 			#	has_tech = modern_small_airframe_2
 			#	factor = 0 #0 #let's not waste XP here
 			#}
@@ -158,10 +158,11 @@ USA_fighter = {
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = empty	
 				special_type_slot_3 = empty	
+
 			}
 		}
 
-		allowed_modules = {
+		allowed_modules = { 
 			aircraft_cannon_2_2x
 			aircraft_cannon_2_2x
 			jet_engine_2x
@@ -169,7 +170,6 @@ USA_fighter = {
 			armor_plate_small
 		}
 	}
-
 	jet_fighter_default_2 = {
 		priority = {
 			factor = 0 #600
@@ -186,11 +186,11 @@ USA_fighter = {
 				engine_type_slot = jet_engine_2x
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = empty	
-				special_type_slot_3 = empty
+				special_type_slot_3 = empty	
 			}
 		}
 
-		allowed_modules = {
+		allowed_modules = { 
 			aircraft_cannon_2_2x
 			aircraft_cannon_2_2x
 			jet_engine_2x
@@ -200,7 +200,6 @@ USA_fighter = {
 		}
 	}
 }
-
 
 USA_cas = {
 	category = air
@@ -217,7 +216,7 @@ USA_cas = {
 	cas_1 = {
 		priority = {
 			factor = 0 #100	
-			modifier = {
+			modifier = { 
 				has_tech = improved_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -230,8 +229,9 @@ USA_cas = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_2_1x
 				special_type_slot_1 = armor_plate_small
-				special_type_slot_2 = fuel_tanks_small
+				special_type_slot_2 = fuel_tanks_small	
 			}
+			
 		}
 
 		allowed_modules = {
@@ -243,11 +243,10 @@ USA_cas = {
 			fuel_tanks_small
 		}
 	}
-
 	cas_2 = {
 		priority = {
 			factor = 0 #200
-			modifier = {
+			modifier = { 
 				has_tech = advanced_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -263,6 +262,7 @@ USA_cas = {
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = fuel_tanks_small	
 				special_type_slot_3 = empty	
+
 			}
 		}
 		allowed_modules = {
@@ -274,11 +274,10 @@ USA_cas = {
 			lmg_defense_turret
 		}
 	}
-
 	cas_3 = {
 		priority = {
 			factor = 0 #200
-			modifier = {
+			modifier = { 
 				has_tech = modern_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -295,6 +294,7 @@ USA_cas = {
 				special_type_slot_1 = hmg_defense_turret
 				special_type_slot_2 = empty	
 				special_type_slot_3 = empty	
+
 			}
 		}
 
@@ -306,11 +306,10 @@ USA_cas = {
 			lmg_defense_turret
 		}
 	}
-
 	cas_4 = {
 		priority = {
 			factor = 0 #200
-			#modifier = {
+			#modifier = { 
 			#	has_tech = modern_small_airframe_2
 			#	factor = 0 #0 #let's not waste XP here
 			#}
@@ -326,7 +325,7 @@ USA_cas = {
 				engine_type_slot = jet_engine_2x
 				special_type_slot_1 = hmg_defense_turret
 				special_type_slot_2 = armor_plate_small	
-				special_type_slot_3 = empty
+				special_type_slot_3 = empty	
 			}
 		}
 
@@ -343,7 +342,6 @@ USA_cas = {
 			armor_plate_small
 		}
 	}
-
 	cas_5 = {
 		priority = {
 			factor = 0 #200
@@ -359,7 +357,7 @@ USA_cas = {
 				engine_type_slot = jet_engine_2x
 				special_type_slot_1 = hmg_defense_turret
 				special_type_slot_2 = armor_plate_small	
-				special_type_slot_3 = empty
+				special_type_slot_3 = empty	
 			}
 		}
 
@@ -379,7 +377,6 @@ USA_cas = {
 	}
 }
 
-
 USA_naval_bomber = {
 	category = air
 
@@ -394,7 +391,7 @@ USA_naval_bomber = {
 	naval_bomber_1 = {
 		priority = {
 			factor = 0 #100
-			modifier = {
+			modifier = { 
 				has_tech = improved_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -407,7 +404,7 @@ USA_naval_bomber = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_2_1x
 				special_type_slot_1 = empty
-				special_type_slot_2 = empty
+				special_type_slot_2 = empty	
 			}
 		}
 		allowed_modules = {
@@ -418,7 +415,7 @@ USA_naval_bomber = {
 	naval_bomber_2 = {
 		priority = {
 			factor = 0 #200
-			modifier = {
+			modifier = { 
 				has_tech = advanced_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -434,6 +431,7 @@ USA_naval_bomber = {
 				special_type_slot_1 = lmg_defense_turret
 				special_type_slot_2 = empty	
 				special_type_slot_3 = empty	
+
 			}
 		}
 		allowed_modules = {
@@ -447,7 +445,7 @@ USA_naval_bomber = {
 	naval_bomber_3 = {
 		priority = {
 			factor = 0 #200
-			modifier = {
+			modifier = { 
 				has_tech = modern_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -464,7 +462,9 @@ USA_naval_bomber = {
 				special_type_slot_1 = lmg_defense_turret
 				special_type_slot_2 = empty	
 				special_type_slot_3 = empty	
+
 			}
+
 		}
 
 		allowed_modules = {
@@ -490,8 +490,9 @@ USA_naval_bomber = {
 				engine_type_slot = jet_engine_1x
 				special_type_slot_1 = hmg_defense_turret
 				special_type_slot_2 = dive_brakes_small	
-				special_type_slot_3 = empty
+				special_type_slot_3 = empty	
 			}
+
 		}
 
 		allowed_modules = {
@@ -506,7 +507,6 @@ USA_naval_bomber = {
 		}
 	}
 }
-
 
 USA_cv_fighter = {
 	category = air
@@ -533,7 +533,7 @@ USA_cv_fighter = {
 	great_war_cv_fighter_default = {
 		priority = {
 			factor = 0 #1
-			modifier = {
+			modifier = { 
 				has_tech = basic_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -547,7 +547,7 @@ USA_cv_fighter = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_1_1x
 				special_type_slot_1 = empty
-				special_type_slot_2 = empty
+				special_type_slot_2 = empty	
 			}
 		}
 
@@ -560,7 +560,7 @@ USA_cv_fighter = {
 	basic_cv_fighter_default = {
 		priority = {
 			factor = 0 #100
-			modifier = {
+			modifier = { 
 				has_tech = improved_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -574,7 +574,7 @@ USA_cv_fighter = {
 				fixed_auxiliary_weapon_slot_1 = heavy_mg_2x
 				engine_type_slot = engine_2_1x
 				special_type_slot_1 = empty
-				special_type_slot_2 = empty
+				special_type_slot_2 = empty	
 			}
 		}
 
@@ -589,7 +589,7 @@ USA_cv_fighter = {
 	improved_cv_fighter_default = {
 		priority = {
 			factor = 0 #10
-			modifier = {
+			modifier = { 
 				has_tech = advanced_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -605,7 +605,7 @@ USA_cv_fighter = {
 				engine_type_slot = engine_3_1x
 				special_type_slot_1 = empty
 				special_type_slot_2 = empty	
-				special_type_slot_3 = empty
+				special_type_slot_3 = empty	
 			}
 		}
 
@@ -619,7 +619,7 @@ USA_cv_fighter = {
 	advanced_cv_fighter_default = {
 		priority = {
 			factor = 0 #10
-			modifier = {
+			modifier = { 
 				has_tech = modern_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -636,10 +636,11 @@ USA_cv_fighter = {
 				engine_type_slot = engine_4_1x
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = { any_of = { rocket_rails bomb_locks } }	
-				special_type_slot_3 = drop_tanks			}
+				special_type_slot_3 = drop_tanks
+			}
 		}
 
-		allowed_modules = {
+		allowed_modules = { 
 			aircraft_cannon_1_2x
 			rocket_rails
 			bomb_locks
@@ -648,11 +649,10 @@ USA_cv_fighter = {
 			armor_plate_small
 		}
 	}
-
 	jet_cv_fighter_default = {
 		priority = {
 			factor = 0 #10
-			#modifier = {
+			#modifier = { 
 			#	has_tech = modern_small_airframe_2
 			#	factor = 0 #0 #let's not waste XP here
 			#}
@@ -669,11 +669,11 @@ USA_cv_fighter = {
 				engine_type_slot = jet_engine_2x
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = drop_tanks	
-				special_type_slot_3 = empty
+				special_type_slot_3 = empty	
 			}
 		}
 
-		allowed_modules = {
+		allowed_modules = { 
 			aircraft_cannon_2_2x
 			aircraft_cannon_2_2x
 			jet_engine_2x
@@ -682,7 +682,6 @@ USA_cv_fighter = {
 			drop_tanks
 		}
 	}
-
 	jet_cv_fighter_default_2 = {
 		priority = {
 			factor = 0 #100
@@ -699,11 +698,11 @@ USA_cv_fighter = {
 				engine_type_slot = jet_engine_2x
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = drop_tanks	
-				special_type_slot_3 = empty
+				special_type_slot_3 = empty	
 			}
 		}
 
-		allowed_modules = {
+		allowed_modules = { 
 			aircraft_cannon_2_2x
 			#aircraft_cannon_3_2x
 			jet_engine_2x
@@ -714,7 +713,6 @@ USA_cv_fighter = {
 		}
 	}
 }
-
 
 USA_cv_cas = {
 	category = air
@@ -740,7 +738,7 @@ USA_cv_cas = {
 	cv_cas_1 = {
 		priority = {
 			factor = 0 #100
-			modifier = {
+			modifier = { 
 				has_tech = improved_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -754,8 +752,9 @@ USA_cv_cas = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_2_1x
 				special_type_slot_1 = dive_brakes_small
-				special_type_slot_2 = empty
+				special_type_slot_2 = empty	
 			}
+			
 		}
 
 		allowed_modules = {
@@ -767,7 +766,7 @@ USA_cv_cas = {
 	cv_cas_2 = {
 		priority = {
 			factor = 0 #200
-			modifier = {
+			modifier = { 
 				has_tech = advanced_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -783,7 +782,7 @@ USA_cv_cas = {
 				engine_type_slot = engine_3_1x
 				special_type_slot_1 = dive_brakes_small
 				special_type_slot_2 = empty	
-				special_type_slot_3 = empty
+				special_type_slot_3 = empty	
 			}
 		}
 
@@ -797,7 +796,7 @@ USA_cv_cas = {
 	cv_cas_3 = {
 		priority = {
 			factor = 0 #200
-			modifier = {
+			modifier = { 
 				has_tech = modern_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -814,7 +813,7 @@ USA_cv_cas = {
 				engine_type_slot = engine_3_1x
 				special_type_slot_1 = dive_brakes_small
 				special_type_slot_2 = empty	
-				special_type_slot_3 = empty
+				special_type_slot_3 = empty	
 			}
 		}
 
@@ -828,6 +827,7 @@ USA_cv_cas = {
 	cv_cas_4 = {
 		priority = {
 			factor = 0 #200
+			
 		}
 
 		target_variant = {
@@ -841,7 +841,7 @@ USA_cv_cas = {
 				engine_type_slot = jet_engine_1x
 				special_type_slot_1 = dive_brakes_small
 				special_type_slot_2 = empty
-				special_type_slot_3 = empty
+				special_type_slot_3 = empty	
 			}
 		}
 
@@ -856,7 +856,6 @@ USA_cv_cas = {
 		}
 	}
 }
-
 
 USA_cv_naval_bomber = {
 	category = air
@@ -882,7 +881,7 @@ USA_cv_naval_bomber = {
 	cv_naval_bomber_1 = {
 		priority = {
 			factor = 0 #100
-			modifier = {
+			modifier = { 
 				has_tech = improved_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -896,7 +895,7 @@ USA_cv_naval_bomber = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_2_1x
 				special_type_slot_1 = empty
-				special_type_slot_2 = empty
+				special_type_slot_2 = empty	
 			}
 		}
 
@@ -908,7 +907,7 @@ USA_cv_naval_bomber = {
 	cv_naval_bomber_2 = {
 		priority = {
 			factor = 0 #200
-			modifier = {
+			modifier = { 
 				has_tech = advanced_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -924,8 +923,9 @@ USA_cv_naval_bomber = {
 				engine_type_slot = engine_3_1x
 				special_type_slot_1 = lmg_defense_turret
 				special_type_slot_2 = empty	
-				special_type_slot_3 = empty
+				special_type_slot_3 = empty	
 			}
+
 		}
 
 		allowed_modules = {
@@ -939,7 +939,7 @@ USA_cv_naval_bomber = {
 	cv_naval_bomber_3 = {
 		priority = {
 			factor = 0 #200
-			modifier = {
+			modifier = { 
 				has_tech = modern_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -956,8 +956,9 @@ USA_cv_naval_bomber = {
 				engine_type_slot = engine_4_1x
 				special_type_slot_1 = lmg_defense_turret
 				special_type_slot_2 = empty	
-				special_type_slot_3 = empty
+				special_type_slot_3 = empty	
 			}
+
 		}
 
 		allowed_modules = {
@@ -973,6 +974,7 @@ USA_cv_naval_bomber = {
 	cv_naval_bomber_4 = {
 		priority = {
 			factor = 0 #200
+			
 		}
 
 		target_variant = {
@@ -986,8 +988,9 @@ USA_cv_naval_bomber = {
 				engine_type_slot = jet_engine_1x
 				special_type_slot_1 = lmg_defense_turret
 				special_type_slot_2 = dive_brakes_small	
-				special_type_slot_3 = empty
+				special_type_slot_3 = empty	
 			}
+
 		}
 
 		allowed_modules = {
@@ -1004,7 +1007,6 @@ USA_cv_naval_bomber = {
 		}
 	}
 }
-
 
 
 
@@ -1032,7 +1034,7 @@ USA_tactical_bomber = {
 	gw_tac_bomber_default = {
 		priority = {
 			factor = 0 #100
-			modifier = {
+			modifier = { 
 				has_tech = basic_medium_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1052,18 +1054,20 @@ USA_tactical_bomber = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 			}
+			
 		}
 
 		allowed_modules = {
 			medium_bomb_bay
 			engine_1_2x
+			
 		}
 	}
 
 	tac_bomber_1_default = {
 		priority = {
 			factor = 0 #100
-			modifier = {
+			modifier = { 
 				has_tech = improved_medium_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1083,6 +1087,7 @@ USA_tactical_bomber = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1093,7 +1098,7 @@ USA_tactical_bomber = {
 	tac_bomber_2_default = {
 		priority = {
 			factor = 0 #100
-			modifier = {
+			modifier = { 
 				has_tech = advanced_medium_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1113,6 +1118,7 @@ USA_tactical_bomber = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1126,7 +1132,7 @@ USA_tactical_bomber = {
 	tac_bomber_3_default = {
 		priority = {
 			factor = 0 #100
-			modifier = {
+			modifier = { 
 				has_tech = modern_medium_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1147,7 +1153,9 @@ USA_tactical_bomber = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 				special_type_slot_5 = empty	
+
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1161,7 +1169,7 @@ USA_tactical_bomber = {
 	jet_tac_bomber_default = {
 		priority = {
 			factor = 0 #100
-			#modifier = {
+			#modifier = { 
 			#	has_tech = modern_medium_airframe_2
 			#	factor = 0 #0 #let's not waste XP here
 			#}
@@ -1182,6 +1190,7 @@ USA_tactical_bomber = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1213,6 +1222,7 @@ USA_tactical_bomber = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1228,7 +1238,6 @@ USA_tactical_bomber = {
 		}
 	}
 }
-
 
 USA_heavy_fighter = {
 	category = air
@@ -1246,7 +1255,7 @@ USA_heavy_fighter = {
 	heavy_fighter_1 = {
 		priority = {
 			factor = 0 #100
-			modifier = {
+			modifier = { 
 				has_tech = improved_medium_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1267,6 +1276,7 @@ USA_heavy_fighter = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1279,7 +1289,7 @@ USA_heavy_fighter = {
 	heavy_fighter_2 = {
 		priority = {
 			factor = 0 #200
-			modifier = {
+			modifier = { 
 				has_tech = advanced_medium_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1297,8 +1307,10 @@ USA_heavy_fighter = {
 				special_type_slot_2 = fuel_tanks_medium	
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
-				special_type_slot_5 = empty
+				special_type_slot_5 = empty	
+
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1313,6 +1325,7 @@ USA_heavy_fighter = {
 	heavy_fighter_3 = {
 		priority = {
 			factor = 0 #200
+			
 		}
 
 		target_variant = {
@@ -1329,8 +1342,10 @@ USA_heavy_fighter = {
 				special_type_slot_2 = fuel_tanks_medium	
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
-				special_type_slot_5 = empty
+				special_type_slot_5 = empty	
+
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1342,7 +1357,6 @@ USA_heavy_fighter = {
 		}
 	}
 }
-
 
 USA_strategic_bomber = {
 	category = air
@@ -1372,7 +1386,7 @@ USA_strategic_bomber = {
 	strat_bomber_1_default = {
 		priority = {
 			factor = 0 #100
-			modifier = {
+			modifier = { 
 				has_tech = improved_large_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1393,6 +1407,7 @@ USA_strategic_bomber = {
 				special_type_slot_4 = empty
 				special_type_slot_5 = empty
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1406,7 +1421,7 @@ USA_strategic_bomber = {
 	strat_bomber_2_default = {
 		priority = {
 			factor = 0 #100
-			modifier = {
+			modifier = { 
 				has_tech = advanced_large_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1435,7 +1450,9 @@ USA_strategic_bomber = {
 				}
 				special_type_slot_5 = empty
 				special_type_slot_6 = empty
+
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1452,7 +1469,7 @@ USA_strategic_bomber = {
 	strat_bomber_3_default = {
 		priority = {
 			factor = 0 #10
-			modifier = {
+			modifier = { 
 				has_tech = modern_large_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1481,7 +1498,9 @@ USA_strategic_bomber = {
 					}
 				}
 				special_type_slot_6 = empty
+
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1500,7 +1519,7 @@ USA_strategic_bomber = {
 	strat_bomber_4_default = {
 		priority = {
 			factor = 0 #10
-			#modifier = {
+			#modifier = { 
 			#	has_tech = modern_large_airframe_2
 			#	factor = 0 #0 #let's not waste XP here
 			#}
@@ -1529,7 +1548,9 @@ USA_strategic_bomber = {
 					}
 				}
 				special_type_slot_6 = empty
+
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1547,7 +1568,6 @@ USA_strategic_bomber = {
 			bomb_sights_1
 		}
 	}
-
 	strat_bomber_5_default = {
 		priority = {
 			factor = 0 #10
@@ -1576,7 +1596,9 @@ USA_strategic_bomber = {
 					}
 				}
 				special_type_slot_6 = empty
+
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1599,7 +1621,6 @@ USA_strategic_bomber = {
 	}
 }
 
-
 USA_maritime_patrol = {
 	category = air
 
@@ -1616,7 +1637,7 @@ USA_maritime_patrol = {
 	maritime_patrol_1_default = {
 		priority = {
 			factor = 0 #10
-			modifier = {
+			modifier = { 
 				has_tech = improved_large_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1637,6 +1658,7 @@ USA_maritime_patrol = {
 				special_type_slot_4 = empty
 				special_type_slot_5 = empty
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1651,10 +1673,11 @@ USA_maritime_patrol = {
 	maritime_patrol_2_default = {
 		priority = {
 			factor = 0 #10
-			modifier = {
+			modifier = { 
 				has_tech = advanced_large_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
+			
 		}
 
 		target_variant = {
@@ -1673,7 +1696,9 @@ USA_maritime_patrol = {
 				special_type_slot_4 = flying_boat_large
 				special_type_slot_5 = empty
 				special_type_slot_6 = empty
+
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1689,6 +1714,7 @@ USA_maritime_patrol = {
 	maritime_patrol_3_default = {
 		priority = {
 			factor = 0 #10
+			
 		}
 
 		target_variant = {
@@ -1702,19 +1728,21 @@ USA_maritime_patrol = {
 				fixed_auxiliary_weapon_slot_4 = empty
 				engine_type_slot = engine_4_4x
 				special_type_slot_1 = cannon_defense_turret_2x
-				special_type_slot_2 = {
+				special_type_slot_2 = { 
 					any_of = {
 						air_ground_radar_2
 						air_ground_radar_1
 						recon_camera
-						hmg_defense_turret_2x
+						hmg_defense_turret_2x 
 					}
 				}
 				special_type_slot_3 = fuel_tanks_large
 				special_type_slot_4 = fuel_tanks_large
 				special_type_slot_5 = flying_boat_large
 				special_type_slot_6 = empty
+
 			}
+			
 		}
 
 		allowed_modules = {
@@ -1730,3 +1758,4 @@ USA_maritime_patrol = {
 		}
 	}
 }
+

--- a/common/ai_equipment/USA_planes.txt
+++ b/common/ai_equipment/USA_planes.txt
@@ -20,7 +20,7 @@ USA_fighter = {
 	great_war_fighter_default = {
 		priority = {
 			factor = 0 #1
-			modifier = { 
+			modifier = {
 				has_tech = basic_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -34,7 +34,7 @@ USA_fighter = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_1_1x
 				special_type_slot_1 = empty
-				special_type_slot_2 = empty	
+				special_type_slot_2 = empty
 			}
 		}
 
@@ -47,7 +47,7 @@ USA_fighter = {
 	basic_fighter_default = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = improved_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -61,7 +61,7 @@ USA_fighter = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_2_1x
 				special_type_slot_1 = empty
-				special_type_slot_2 = empty	
+				special_type_slot_2 = empty
 			}
 		}
 
@@ -78,7 +78,7 @@ USA_fighter = {
 	improved_fighter_default = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = advanced_small_airframe 
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -95,7 +95,6 @@ USA_fighter = {
 				special_type_slot_1 = drop_tanks
 				special_type_slot_2 = fuel_tanks_small	
 				special_type_slot_3 = empty	
-
 			}
 		}
 
@@ -109,7 +108,7 @@ USA_fighter = {
 	advanced_fighter_default = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = modern_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -126,21 +125,22 @@ USA_fighter = {
 				engine_type_slot = engine_4_1x
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = drop_tanks
-				special_type_slot_3 = fuel_tanks_small	
+				special_type_slot_3 = fuel_tanks_small
 			}
 		}
 
-		allowed_modules = { 
+		allowed_modules = {
 			drop_tanks
 			heavy_mg_4x
 			engine_4_1x
 			armor_plate_small
 		}
 	}
+
 	jet_fighter_default = {
 		priority = {
 			factor = 0 #600
-			#modifier = { 
+			#modifier = {
 			#	has_tech = modern_small_airframe_2
 			#	factor = 0 #0 #let's not waste XP here
 			#}
@@ -158,11 +158,10 @@ USA_fighter = {
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = empty	
 				special_type_slot_3 = empty	
-
 			}
 		}
 
-		allowed_modules = { 
+		allowed_modules = {
 			aircraft_cannon_2_2x
 			aircraft_cannon_2_2x
 			jet_engine_2x
@@ -170,6 +169,7 @@ USA_fighter = {
 			armor_plate_small
 		}
 	}
+
 	jet_fighter_default_2 = {
 		priority = {
 			factor = 0 #600
@@ -186,11 +186,11 @@ USA_fighter = {
 				engine_type_slot = jet_engine_2x
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = empty	
-				special_type_slot_3 = empty	
+				special_type_slot_3 = empty
 			}
 		}
 
-		allowed_modules = { 
+		allowed_modules = {
 			aircraft_cannon_2_2x
 			aircraft_cannon_2_2x
 			jet_engine_2x
@@ -200,6 +200,7 @@ USA_fighter = {
 		}
 	}
 }
+
 
 USA_cas = {
 	category = air
@@ -216,7 +217,7 @@ USA_cas = {
 	cas_1 = {
 		priority = {
 			factor = 0 #100	
-			modifier = { 
+			modifier = {
 				has_tech = improved_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -229,9 +230,8 @@ USA_cas = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_2_1x
 				special_type_slot_1 = armor_plate_small
-				special_type_slot_2 = fuel_tanks_small	
+				special_type_slot_2 = fuel_tanks_small
 			}
-			
 		}
 
 		allowed_modules = {
@@ -243,10 +243,11 @@ USA_cas = {
 			fuel_tanks_small
 		}
 	}
+
 	cas_2 = {
 		priority = {
 			factor = 0 #200
-			modifier = { 
+			modifier = {
 				has_tech = advanced_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -262,7 +263,6 @@ USA_cas = {
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = fuel_tanks_small	
 				special_type_slot_3 = empty	
-
 			}
 		}
 		allowed_modules = {
@@ -274,10 +274,11 @@ USA_cas = {
 			lmg_defense_turret
 		}
 	}
+
 	cas_3 = {
 		priority = {
 			factor = 0 #200
-			modifier = { 
+			modifier = {
 				has_tech = modern_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -294,7 +295,6 @@ USA_cas = {
 				special_type_slot_1 = hmg_defense_turret
 				special_type_slot_2 = empty	
 				special_type_slot_3 = empty	
-
 			}
 		}
 
@@ -306,10 +306,11 @@ USA_cas = {
 			lmg_defense_turret
 		}
 	}
+
 	cas_4 = {
 		priority = {
 			factor = 0 #200
-			#modifier = { 
+			#modifier = {
 			#	has_tech = modern_small_airframe_2
 			#	factor = 0 #0 #let's not waste XP here
 			#}
@@ -325,7 +326,7 @@ USA_cas = {
 				engine_type_slot = jet_engine_2x
 				special_type_slot_1 = hmg_defense_turret
 				special_type_slot_2 = armor_plate_small	
-				special_type_slot_3 = empty	
+				special_type_slot_3 = empty
 			}
 		}
 
@@ -342,6 +343,7 @@ USA_cas = {
 			armor_plate_small
 		}
 	}
+
 	cas_5 = {
 		priority = {
 			factor = 0 #200
@@ -357,7 +359,7 @@ USA_cas = {
 				engine_type_slot = jet_engine_2x
 				special_type_slot_1 = hmg_defense_turret
 				special_type_slot_2 = armor_plate_small	
-				special_type_slot_3 = empty	
+				special_type_slot_3 = empty
 			}
 		}
 
@@ -377,6 +379,7 @@ USA_cas = {
 	}
 }
 
+
 USA_naval_bomber = {
 	category = air
 
@@ -391,7 +394,7 @@ USA_naval_bomber = {
 	naval_bomber_1 = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = improved_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -404,7 +407,7 @@ USA_naval_bomber = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_2_1x
 				special_type_slot_1 = empty
-				special_type_slot_2 = empty	
+				special_type_slot_2 = empty
 			}
 		}
 		allowed_modules = {
@@ -415,7 +418,7 @@ USA_naval_bomber = {
 	naval_bomber_2 = {
 		priority = {
 			factor = 0 #200
-			modifier = { 
+			modifier = {
 				has_tech = advanced_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -431,7 +434,6 @@ USA_naval_bomber = {
 				special_type_slot_1 = lmg_defense_turret
 				special_type_slot_2 = empty	
 				special_type_slot_3 = empty	
-
 			}
 		}
 		allowed_modules = {
@@ -445,7 +447,7 @@ USA_naval_bomber = {
 	naval_bomber_3 = {
 		priority = {
 			factor = 0 #200
-			modifier = { 
+			modifier = {
 				has_tech = modern_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -462,9 +464,7 @@ USA_naval_bomber = {
 				special_type_slot_1 = lmg_defense_turret
 				special_type_slot_2 = empty	
 				special_type_slot_3 = empty	
-
 			}
-
 		}
 
 		allowed_modules = {
@@ -490,9 +490,8 @@ USA_naval_bomber = {
 				engine_type_slot = jet_engine_1x
 				special_type_slot_1 = hmg_defense_turret
 				special_type_slot_2 = dive_brakes_small	
-				special_type_slot_3 = empty	
+				special_type_slot_3 = empty
 			}
-
 		}
 
 		allowed_modules = {
@@ -507,6 +506,7 @@ USA_naval_bomber = {
 		}
 	}
 }
+
 
 USA_cv_fighter = {
 	category = air
@@ -533,7 +533,7 @@ USA_cv_fighter = {
 	great_war_cv_fighter_default = {
 		priority = {
 			factor = 0 #1
-			modifier = { 
+			modifier = {
 				has_tech = basic_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -547,7 +547,7 @@ USA_cv_fighter = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_1_1x
 				special_type_slot_1 = empty
-				special_type_slot_2 = empty	
+				special_type_slot_2 = empty
 			}
 		}
 
@@ -560,7 +560,7 @@ USA_cv_fighter = {
 	basic_cv_fighter_default = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = improved_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -574,7 +574,7 @@ USA_cv_fighter = {
 				fixed_auxiliary_weapon_slot_1 = heavy_mg_2x
 				engine_type_slot = engine_2_1x
 				special_type_slot_1 = empty
-				special_type_slot_2 = empty	
+				special_type_slot_2 = empty
 			}
 		}
 
@@ -589,7 +589,7 @@ USA_cv_fighter = {
 	improved_cv_fighter_default = {
 		priority = {
 			factor = 0 #10
-			modifier = { 
+			modifier = {
 				has_tech = advanced_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -605,7 +605,7 @@ USA_cv_fighter = {
 				engine_type_slot = engine_3_1x
 				special_type_slot_1 = empty
 				special_type_slot_2 = empty	
-				special_type_slot_3 = empty	
+				special_type_slot_3 = empty
 			}
 		}
 
@@ -619,7 +619,7 @@ USA_cv_fighter = {
 	advanced_cv_fighter_default = {
 		priority = {
 			factor = 0 #10
-			modifier = { 
+			modifier = {
 				has_tech = modern_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -636,11 +636,10 @@ USA_cv_fighter = {
 				engine_type_slot = engine_4_1x
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = { any_of = { rocket_rails bomb_locks } }	
-				special_type_slot_3 = drop_tanks
-			}
+				special_type_slot_3 = drop_tanks			}
 		}
 
-		allowed_modules = { 
+		allowed_modules = {
 			aircraft_cannon_1_2x
 			rocket_rails
 			bomb_locks
@@ -649,10 +648,11 @@ USA_cv_fighter = {
 			armor_plate_small
 		}
 	}
+
 	jet_cv_fighter_default = {
 		priority = {
 			factor = 0 #10
-			#modifier = { 
+			#modifier = {
 			#	has_tech = modern_small_airframe_2
 			#	factor = 0 #0 #let's not waste XP here
 			#}
@@ -669,11 +669,11 @@ USA_cv_fighter = {
 				engine_type_slot = jet_engine_2x
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = drop_tanks	
-				special_type_slot_3 = empty	
+				special_type_slot_3 = empty
 			}
 		}
 
-		allowed_modules = { 
+		allowed_modules = {
 			aircraft_cannon_2_2x
 			aircraft_cannon_2_2x
 			jet_engine_2x
@@ -682,6 +682,7 @@ USA_cv_fighter = {
 			drop_tanks
 		}
 	}
+
 	jet_cv_fighter_default_2 = {
 		priority = {
 			factor = 0 #100
@@ -698,11 +699,11 @@ USA_cv_fighter = {
 				engine_type_slot = jet_engine_2x
 				special_type_slot_1 = armor_plate_small
 				special_type_slot_2 = drop_tanks	
-				special_type_slot_3 = empty	
+				special_type_slot_3 = empty
 			}
 		}
 
-		allowed_modules = { 
+		allowed_modules = {
 			aircraft_cannon_2_2x
 			#aircraft_cannon_3_2x
 			jet_engine_2x
@@ -713,6 +714,7 @@ USA_cv_fighter = {
 		}
 	}
 }
+
 
 USA_cv_cas = {
 	category = air
@@ -738,7 +740,7 @@ USA_cv_cas = {
 	cv_cas_1 = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = improved_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -752,9 +754,8 @@ USA_cv_cas = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_2_1x
 				special_type_slot_1 = dive_brakes_small
-				special_type_slot_2 = empty	
+				special_type_slot_2 = empty
 			}
-			
 		}
 
 		allowed_modules = {
@@ -766,7 +767,7 @@ USA_cv_cas = {
 	cv_cas_2 = {
 		priority = {
 			factor = 0 #200
-			modifier = { 
+			modifier = {
 				has_tech = advanced_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -782,7 +783,7 @@ USA_cv_cas = {
 				engine_type_slot = engine_3_1x
 				special_type_slot_1 = dive_brakes_small
 				special_type_slot_2 = empty	
-				special_type_slot_3 = empty	
+				special_type_slot_3 = empty
 			}
 		}
 
@@ -796,7 +797,7 @@ USA_cv_cas = {
 	cv_cas_3 = {
 		priority = {
 			factor = 0 #200
-			modifier = { 
+			modifier = {
 				has_tech = modern_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -813,7 +814,7 @@ USA_cv_cas = {
 				engine_type_slot = engine_3_1x
 				special_type_slot_1 = dive_brakes_small
 				special_type_slot_2 = empty	
-				special_type_slot_3 = empty	
+				special_type_slot_3 = empty
 			}
 		}
 
@@ -827,7 +828,6 @@ USA_cv_cas = {
 	cv_cas_4 = {
 		priority = {
 			factor = 0 #200
-			
 		}
 
 		target_variant = {
@@ -841,7 +841,7 @@ USA_cv_cas = {
 				engine_type_slot = jet_engine_1x
 				special_type_slot_1 = dive_brakes_small
 				special_type_slot_2 = empty
-				special_type_slot_3 = empty	
+				special_type_slot_3 = empty
 			}
 		}
 
@@ -856,6 +856,7 @@ USA_cv_cas = {
 		}
 	}
 }
+
 
 USA_cv_naval_bomber = {
 	category = air
@@ -881,7 +882,7 @@ USA_cv_naval_bomber = {
 	cv_naval_bomber_1 = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = improved_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -895,7 +896,7 @@ USA_cv_naval_bomber = {
 				fixed_auxiliary_weapon_slot_1 = empty
 				engine_type_slot = engine_2_1x
 				special_type_slot_1 = empty
-				special_type_slot_2 = empty	
+				special_type_slot_2 = empty
 			}
 		}
 
@@ -907,7 +908,7 @@ USA_cv_naval_bomber = {
 	cv_naval_bomber_2 = {
 		priority = {
 			factor = 0 #200
-			modifier = { 
+			modifier = {
 				has_tech = advanced_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -923,9 +924,8 @@ USA_cv_naval_bomber = {
 				engine_type_slot = engine_3_1x
 				special_type_slot_1 = lmg_defense_turret
 				special_type_slot_2 = empty	
-				special_type_slot_3 = empty	
+				special_type_slot_3 = empty
 			}
-
 		}
 
 		allowed_modules = {
@@ -939,7 +939,7 @@ USA_cv_naval_bomber = {
 	cv_naval_bomber_3 = {
 		priority = {
 			factor = 0 #200
-			modifier = { 
+			modifier = {
 				has_tech = modern_small_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -956,9 +956,8 @@ USA_cv_naval_bomber = {
 				engine_type_slot = engine_4_1x
 				special_type_slot_1 = lmg_defense_turret
 				special_type_slot_2 = empty	
-				special_type_slot_3 = empty	
+				special_type_slot_3 = empty
 			}
-
 		}
 
 		allowed_modules = {
@@ -974,7 +973,6 @@ USA_cv_naval_bomber = {
 	cv_naval_bomber_4 = {
 		priority = {
 			factor = 0 #200
-			
 		}
 
 		target_variant = {
@@ -988,9 +986,8 @@ USA_cv_naval_bomber = {
 				engine_type_slot = jet_engine_1x
 				special_type_slot_1 = lmg_defense_turret
 				special_type_slot_2 = dive_brakes_small	
-				special_type_slot_3 = empty	
+				special_type_slot_3 = empty
 			}
-
 		}
 
 		allowed_modules = {
@@ -1007,6 +1004,7 @@ USA_cv_naval_bomber = {
 		}
 	}
 }
+
 
 
 
@@ -1034,7 +1032,7 @@ USA_tactical_bomber = {
 	gw_tac_bomber_default = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = basic_medium_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1054,20 +1052,18 @@ USA_tactical_bomber = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 			}
-			
 		}
 
 		allowed_modules = {
 			medium_bomb_bay
 			engine_1_2x
-			
 		}
 	}
 
 	tac_bomber_1_default = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = improved_medium_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1087,7 +1083,6 @@ USA_tactical_bomber = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1098,7 +1093,7 @@ USA_tactical_bomber = {
 	tac_bomber_2_default = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = advanced_medium_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1118,7 +1113,6 @@ USA_tactical_bomber = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1132,7 +1126,7 @@ USA_tactical_bomber = {
 	tac_bomber_3_default = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = modern_medium_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1153,9 +1147,7 @@ USA_tactical_bomber = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 				special_type_slot_5 = empty	
-
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1169,7 +1161,7 @@ USA_tactical_bomber = {
 	jet_tac_bomber_default = {
 		priority = {
 			factor = 0 #100
-			#modifier = { 
+			#modifier = {
 			#	has_tech = modern_medium_airframe_2
 			#	factor = 0 #0 #let's not waste XP here
 			#}
@@ -1190,7 +1182,6 @@ USA_tactical_bomber = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1222,7 +1213,6 @@ USA_tactical_bomber = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1238,6 +1228,7 @@ USA_tactical_bomber = {
 		}
 	}
 }
+
 
 USA_heavy_fighter = {
 	category = air
@@ -1255,7 +1246,7 @@ USA_heavy_fighter = {
 	heavy_fighter_1 = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = improved_medium_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1276,7 +1267,6 @@ USA_heavy_fighter = {
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1289,7 +1279,7 @@ USA_heavy_fighter = {
 	heavy_fighter_2 = {
 		priority = {
 			factor = 0 #200
-			modifier = { 
+			modifier = {
 				has_tech = advanced_medium_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1307,10 +1297,8 @@ USA_heavy_fighter = {
 				special_type_slot_2 = fuel_tanks_medium	
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
-				special_type_slot_5 = empty	
-
+				special_type_slot_5 = empty
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1325,7 +1313,6 @@ USA_heavy_fighter = {
 	heavy_fighter_3 = {
 		priority = {
 			factor = 0 #200
-			
 		}
 
 		target_variant = {
@@ -1342,10 +1329,8 @@ USA_heavy_fighter = {
 				special_type_slot_2 = fuel_tanks_medium	
 				special_type_slot_3 = empty
 				special_type_slot_4 = empty
-				special_type_slot_5 = empty	
-
+				special_type_slot_5 = empty
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1357,6 +1342,7 @@ USA_heavy_fighter = {
 		}
 	}
 }
+
 
 USA_strategic_bomber = {
 	category = air
@@ -1386,7 +1372,7 @@ USA_strategic_bomber = {
 	strat_bomber_1_default = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = improved_large_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1407,7 +1393,6 @@ USA_strategic_bomber = {
 				special_type_slot_4 = empty
 				special_type_slot_5 = empty
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1421,7 +1406,7 @@ USA_strategic_bomber = {
 	strat_bomber_2_default = {
 		priority = {
 			factor = 0 #100
-			modifier = { 
+			modifier = {
 				has_tech = advanced_large_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1450,9 +1435,7 @@ USA_strategic_bomber = {
 				}
 				special_type_slot_5 = empty
 				special_type_slot_6 = empty
-
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1469,7 +1452,7 @@ USA_strategic_bomber = {
 	strat_bomber_3_default = {
 		priority = {
 			factor = 0 #10
-			modifier = { 
+			modifier = {
 				has_tech = modern_large_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1498,9 +1481,7 @@ USA_strategic_bomber = {
 					}
 				}
 				special_type_slot_6 = empty
-
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1519,7 +1500,7 @@ USA_strategic_bomber = {
 	strat_bomber_4_default = {
 		priority = {
 			factor = 0 #10
-			#modifier = { 
+			#modifier = {
 			#	has_tech = modern_large_airframe_2
 			#	factor = 0 #0 #let's not waste XP here
 			#}
@@ -1548,9 +1529,7 @@ USA_strategic_bomber = {
 					}
 				}
 				special_type_slot_6 = empty
-
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1568,6 +1547,7 @@ USA_strategic_bomber = {
 			bomb_sights_1
 		}
 	}
+
 	strat_bomber_5_default = {
 		priority = {
 			factor = 0 #10
@@ -1596,9 +1576,7 @@ USA_strategic_bomber = {
 					}
 				}
 				special_type_slot_6 = empty
-
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1621,6 +1599,7 @@ USA_strategic_bomber = {
 	}
 }
 
+
 USA_maritime_patrol = {
 	category = air
 
@@ -1637,7 +1616,7 @@ USA_maritime_patrol = {
 	maritime_patrol_1_default = {
 		priority = {
 			factor = 0 #10
-			modifier = { 
+			modifier = {
 				has_tech = improved_large_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
@@ -1658,7 +1637,6 @@ USA_maritime_patrol = {
 				special_type_slot_4 = empty
 				special_type_slot_5 = empty
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1673,11 +1651,10 @@ USA_maritime_patrol = {
 	maritime_patrol_2_default = {
 		priority = {
 			factor = 0 #10
-			modifier = { 
+			modifier = {
 				has_tech = advanced_large_airframe
 				factor = 0 #0 #let's not waste XP here
 			}
-			
 		}
 
 		target_variant = {
@@ -1696,9 +1673,7 @@ USA_maritime_patrol = {
 				special_type_slot_4 = flying_boat_large
 				special_type_slot_5 = empty
 				special_type_slot_6 = empty
-
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1714,7 +1689,6 @@ USA_maritime_patrol = {
 	maritime_patrol_3_default = {
 		priority = {
 			factor = 0 #10
-			
 		}
 
 		target_variant = {
@@ -1728,7 +1702,7 @@ USA_maritime_patrol = {
 				fixed_auxiliary_weapon_slot_4 = empty
 				engine_type_slot = engine_4_4x
 				special_type_slot_1 = cannon_defense_turret_2x
-				special_type_slot_2 = { 
+				special_type_slot_2 = {
 					any_of = {
 						air_ground_radar_2
 						air_ground_radar_1
@@ -1740,9 +1714,7 @@ USA_maritime_patrol = {
 				special_type_slot_4 = fuel_tanks_large
 				special_type_slot_5 = flying_boat_large
 				special_type_slot_6 = empty
-
 			}
-			
 		}
 
 		allowed_modules = {
@@ -1758,4 +1730,3 @@ USA_maritime_patrol = {
 		}
 	}
 }
-

--- a/common/technologies/bba_air_techs.txt
+++ b/common/technologies/bba_air_techs.txt
@@ -1014,7 +1014,7 @@ technologies = {
 
 		folder = {
 			name = bba_air_techs_folder
-			position = { x = 0 y = 10 }
+			position = { x = 0 y = 8 }
 		}
 
 		categories = {

--- a/interface/countrytechtreeview.gui
+++ b/interface/countrytechtreeview.gui
@@ -2737,107 +2737,112 @@ guiTypes = {
 					position = { x=0 y=0 }
 					alwaystransparent = yes
 				}
-
 			}
 
-			instantTextBoxType = {
-				name = "airtech_year2"
-				position = { x = 20 y = 160 }
-				textureFile = ""
-				font = "hoi_36header"
-				borderSize = {x = 0 y = 4}
-				text = "1933"
-				maxWidth = 170
-				maxHeight = 32
-				format = left
-				Orientation = "UPPER_LEFT"
-			}
+			containerWindowType = {
+				name = "airtech_year_left"
+				position = { x=0 y=25 }
+				size = { width = 130 height = 100% }
+				orientation = upper_left
 
-			instantTextBoxType = {
-				name = "airtech_year3"
-				position = { x = 20 y = 298 }
-				textureFile = ""
-				font = "hoi_36header"
-				borderSize = {x = 0 y = 4}
-				text = "1936"
-				maxWidth = 170
-				maxHeight = 32
-				format = left
-				Orientation = "UPPER_LEFT"
-			}
+				instantTextBoxType = {
+					name = "airtech_year2"
+					position = { x = 20 y = 160 }
+					textureFile = ""
+					font = "hoi_36header"
+					borderSize = {x = 0 y = 4}
+					text = "1933"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
 
-			instantTextBoxType = {
-				name = "airtech_year4"
-				position = { x = 20 y = 440 }
-				textureFile = ""
-				font = "hoi_36header"
-				borderSize = {x = 0 y = 4}
-				text = "1940"
-				maxWidth = 170
-				maxHeight = 32
-				format = left
-				Orientation = "UPPER_LEFT"
-			}
+				instantTextBoxType = {
+					name = "airtech_year3"
+					position = { x = 20 y = 298 }
+					textureFile = ""
+					font = "hoi_36header"
+					borderSize = {x = 0 y = 4}
+					text = "1936"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
 
-			instantTextBoxType = {
-				name = "airtech_year5"
-				position = { x = 20 y = 580 }
-				textureFile = ""
-				font = "hoi_36header"
-				borderSize = {x = 0 y = 4}
-				text = "1944"
-				maxWidth = 170
-				maxHeight = 32
-				format = left
-				Orientation = "UPPER_LEFT"
-			}
+				instantTextBoxType = {
+					name = "airtech_year4"
+					position = { x = 20 y = 440 }
+					textureFile = ""
+					font = "hoi_36header"
+					borderSize = {x = 0 y = 4}
+					text = "1940"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
 
-			instantTextBoxType = {
-				name = "airtech_year6"
-				position = { x = 20 y = 858 }
-				textureFile = ""
-				font = "hoi_36header"
-				borderSize = {x = 0 y = 4}
-				text = "1945"
-				maxWidth = 170
-				maxHeight = 32
-				format = left
-				Orientation = "UPPER_LEFT"
-			}
+				instantTextBoxType = {
+					name = "airtech_year5"
+					position = { x = 20 y = 580 }
+					textureFile = ""
+					font = "hoi_36header"
+					borderSize = {x = 0 y = 4}
+					text = "1944"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
 
-			instantTextBoxType = {
-				name = "airtech_year7"
-				position = { x = 20 y = 998 }
-				textureFile = ""
-				font = "hoi_36header"
-				borderSize = {x = 0 y = 4}
-				text = "1950"
-				maxWidth = 170
-				maxHeight = 32
-				format = left
-				Orientation = "UPPER_LEFT"
-			}
+				instantTextBoxType = {
+					name = "airtech_year6"
+					position = { x = 20 y = 858 }
+					textureFile = ""
+					font = "hoi_36header"
+					borderSize = {x = 0 y = 4}
+					text = "1945"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
 
-###------> New Air Date Text B <><> <><> <><> <><> <><>
+				instantTextBoxType = {
+					name = "airtech_year7"
+					position = { x = 20 y = 998 }
+					textureFile = ""
+					font = "hoi_36header"
+					borderSize = {x = 0 y = 4}
+					text = "1950"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
 
-			instantTextBoxType = {
-				name = "airtech_year8"
-				position = { x = 20 y = 1138 }
-				textureFile = ""
-				font = "hoi_36header"
-				borderSize = {x = 0 y = 4}
-				text = "1955"
-				maxWidth = 170
-				maxHeight = 32
-				format = left
-				Orientation = "UPPER_LEFT"
+				# New Air Date Text B <><> <><> <><> <><> <><>
+				instantTextBoxType = {
+					name = "airtech_year8"
+					position = { x = 20 y = 1138 }
+					textureFile = ""
+					font = "hoi_36header"
+					borderSize = {x = 0 y = 4}
+					text = "1955"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
 			}
 
 ###------> X <><> <><> <><> <><> <><>
 
 			containerWindowType = {
-				name = "airtech_year_left"
-				position = { x=2300 y=0 }
+				name = "airtech_year_right"
+				position = { x=2300 y=25 }
 				size = { width = 130 height = 100% }
 				orientation = upper_left
 
@@ -3341,19 +3346,6 @@ guiTypes = {
 					format = left
 					Orientation = "UPPER_LEFT"
 				}
-
-				instantTextBoxType = {
-					name = "airtech_year7"
-					position = { x = 30 y = 998 }
-					textureFile = ""
-					font = "hoi_36header"
-					borderSize = {x = 0 y = 4}
-					text = "1950"
-					maxWidth = 170
-					maxHeight = 32
-					format = left
-					Orientation = "UPPER_LEFT"
-				}
 			}
 
 			containerWindowType = {
@@ -3421,19 +3413,6 @@ guiTypes = {
 					font = "hoi_36header"
 					borderSize = {x = 0 y = 4}
 					text = "1945"
-					maxWidth = 170
-					maxHeight = 32
-					format = right
-					Orientation = "UPPER_LEFT"
-				}
-
-				instantTextBoxType = {
-					name = "airtech_year7"
-					position = { x = 60 y = 998 }
-					textureFile = ""
-					font = "hoi_36header"
-					borderSize = {x = 0 y = 4}
-					text = "1950"
 					maxWidth = 170
 					maxHeight = 32
 					format = right

--- a/interface/countrytechtreeview.gui
+++ b/interface/countrytechtreeview.gui
@@ -3269,90 +3269,96 @@ guiTypes = {
 					position = { x=0 y=0 }
 					alwaystransparent = yes
 				}
-
-			}
-
-			instantTextBoxType = {
-				name = "airtech_year2"
-				position = { x = 30 y = 160 }
-				textureFile = ""
-				font = "hoi_36header"
-				borderSize = {x = 0 y = 4}
-				text = "1933"
-				maxWidth = 170
-				maxHeight = 32
-				format = left
-				Orientation = "UPPER_LEFT"
-			}
-
-			instantTextBoxType = {
-				name = "airtech_year3"
-				position = { x = 30 y = 298 }
-				textureFile = ""
-				font = "hoi_36header"
-				borderSize = {x = 0 y = 4}
-				text = "1936"
-				maxWidth = 170
-				maxHeight = 32
-				format = left
-				Orientation = "UPPER_LEFT"
-			}
-
-			instantTextBoxType = {
-				name = "airtech_year4"
-				position = { x = 30 y = 440 }
-				textureFile = ""
-				font = "hoi_36header"
-				borderSize = {x = 0 y = 4}
-				text = "1940"
-				maxWidth = 170
-				maxHeight = 32
-				format = left
-				Orientation = "UPPER_LEFT"
-			}
-
-			instantTextBoxType = {
-				name = "airtech_year5"
-				position = { x = 30 y = 580 }
-				textureFile = ""
-				font = "hoi_36header"
-				borderSize = {x = 0 y = 4}
-				text = "1944"
-				maxWidth = 170
-				maxHeight = 32
-				format = left
-				Orientation = "UPPER_LEFT"
-			}
-
-			instantTextBoxType = {
-				name = "airtech_year6"
-				position = { x = 30 y = 858 }
-				textureFile = ""
-				font = "hoi_36header"
-				borderSize = {x = 0 y = 4}
-				text = "1945"
-				maxWidth = 170
-				maxHeight = 32
-				format = left
-				Orientation = "UPPER_LEFT"
-			}
-
-			instantTextBoxType = {
-				name = "airtech_year7"
-				position = { x = 30 y = 998 }
-				textureFile = ""
-				font = "hoi_36header"
-				borderSize = {x = 0 y = 4}
-				text = "1950"
-				maxWidth = 170
-				maxHeight = 32
-				format = left
-				Orientation = "UPPER_LEFT"
 			}
 
 			containerWindowType = {
 				name = "airtech_year_left"
-				position = { x=1750 y=0 }
+				position = { x=0 y=25 }
+				size = { width = 200 height = 100% }
+				orientation = upper_left
+
+				instantTextBoxType = {
+					name = "airtech_year2"
+					position = { x = 30 y = 160 }
+					textureFile = ""
+					font = "hoi_36header"
+					borderSize = {x = 0 y = 4}
+					text = "1933"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
+
+				instantTextBoxType = {
+					name = "airtech_year3"
+					position = { x = 30 y = 300 }
+					textureFile = ""
+					font = "hoi_36header"
+					borderSize = {x = 0 y = 4}
+					text = "1936"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
+
+				instantTextBoxType = {
+					name = "airtech_year4"
+					position = { x = 30 y = 440 }
+					textureFile = ""
+					font = "hoi_36header"
+					borderSize = {x = 0 y = 4}
+					text = "1940"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
+
+				instantTextBoxType = {
+					name = "airtech_year5"
+					position = { x = 30 y = 580 }
+					textureFile = ""
+					font = "hoi_36header"
+					borderSize = {x = 0 y = 4}
+					text = "1944"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
+
+				instantTextBoxType = {
+					name = "airtech_year6"
+					position = { x = 30 y = 865 }
+					textureFile = ""
+					font = "hoi_36header"
+					borderSize = {x = 0 y = 4}
+					text = "1945"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
+
+				instantTextBoxType = {
+					name = "airtech_year7"
+					position = { x = 30 y = 998 }
+					textureFile = ""
+					font = "hoi_36header"
+					borderSize = {x = 0 y = 4}
+					text = "1950"
+					maxWidth = 170
+					maxHeight = 32
+					format = left
+					Orientation = "UPPER_LEFT"
+				}
+			}
+
+			containerWindowType = {
+				name = "airtech_year_right"
+				position = { x=1750 y=25 }
 				size = { width = 200 height = 100% }
 				orientation = upper_left
 
@@ -3371,7 +3377,7 @@ guiTypes = {
 
 				instantTextBoxType = {
 					name = "airtech_year3"
-					position = { x = 60 y = 298 }
+					position = { x = 60 y = 300 }
 					textureFile = ""
 					font = "hoi_36header"
 					borderSize = {x = 0 y = 4}
@@ -3410,7 +3416,7 @@ guiTypes = {
 
 				instantTextBoxType = {
 					name = "airtech_year6"
-					position = { x = 60 y = 858 }
+					position = { x = 60 y = 865 }
 					textureFile = ""
 					font = "hoi_36header"
 					borderSize = {x = 0 y = 4}


### PR DESCRIPTION
Slight adjustment to the position of the "year markers" in the aviation tech tree. They are now aligned better. An unused "1950" label was removed. 

Also moved Air Torpedo 3 to match its year.

Tested with and without BBA.