### PR TITLE
#Fix incorrect requirements for `INS_claim_timor`

### DIFF
--- a/common/national_focus/indonesia.txt
+++ b/common/national_focus/indonesia.txt
@@ -3375,15 +3375,9 @@ focus_tree = {
 					is_subject_of = ROOT
 					has_war_with = ROOT
 				}
-				OR = {
-					AND = {
-						controls_state = 523
-						owns_state = 523
-					}
-					AND = {
-						controls_state = 737
-						owns_state = 737
-					}
+				AND = {
+					controls_state = 721
+					owns_state = 721
 				}
 			}
 		}


### PR DESCRIPTION
# Fix incorrect requirements for `INS_claim_timor`

## Description

The Indonesian focus tree has two similar focuses `Continue the Expedition` `(INS_claim_guinea)` and `Unite Pulau Timor` `(INS_claim_timor)`. Both focuses send an event to their respective country demanding ownership of Australian and Portuguese territory respectively. Both focuses have the exact same `available` section that needs to be fulfilled in order to start the focus. Each respective focus requires that any other country must own the territory in question and not: 
1. Be in your faction
2. Be your puppet
3. Be at war with you
However, both focuses check for ownership of Paupa and Bismark. Since both of these focuses are so similar I believe that during development the requirements for `Claim Guinea` were copy-pasted to `Claim Timor` and forgotten.

## Implimentation

I changed the `available` section of `INS_claim_timor` to check for `controls_state = 721`.

## Notes

The README said to look in the coding channel of the Discord server in order to get the `.mod` file. Could be a skill issue on my part, but I was unable to find it so I wasn't able to actually test my changes.