### PR TITLE
Women's rights actually matter now.

### DIFF
--- a/common/ideas/r56i_laws_gender.txt
+++ b/common/ideas/r56i_laws_gender.txt
@@ -31,11 +31,16 @@ ideas = {
 			}
 			
 			modifier = {
-				industrial_capacity_factory = 0.05
-				industrial_capacity_dockyard = 0.05
-				production_factory_efficiency_gain_factor = 0.05
-				production_speed_facility_factor = -0.075
+				production_speed_buildings_factor = 0.05
+				industrial_capacity_dockyard = -0.05
+				industrial_capacity_factory = -0.05
+				army_core_attack_factor = 0.05
+				army_core_defence_factor = 0.05
+				research_speed_factor = -0.05
 				conscription_factor = -0.075
+				monthly_population = 0.05
+				stability_factor = 0.05
+				war_support_factor = -0.05
 				hidden_modifier = { #Needs to hide for non DLC plebs
 					female_random_operative_chance = -1
 					female_random_scientist_chance = -1
@@ -113,11 +118,16 @@ ideas = {
 			}
 			
 			modifier = {
-				industrial_capacity_factory = 0.075
-				industrial_capacity_dockyard = 0.075
-				production_factory_efficiency_gain_factor = 0.10
-				production_speed_facility_factor = -0.15
+				production_speed_buildings_factor = 0.1
+				industrial_capacity_dockyard = -0.1
+				industrial_capacity_factory = -0.1
+				army_core_attack_factor = 0.1
+				army_core_defence_factor = 0.1
+				research_speed_factor = -0.1
 				conscription_factor = -0.15
+				monthly_population = 0.1
+				stability_factor = 0.1
+				war_support_factor = -0.1
 				hidden_modifier = { #Needs to hide for non DLC plebs
 					female_random_operative_chance = -2
 					female_random_scientist_chance = -2
@@ -150,12 +160,17 @@ ideas = {
 			}
 
 			modifier = {
-				industrial_capacity_factory = -0.05
-				industrial_capacity_dockyard = -0.05
-				production_speed_facility_factor = 0.075
-				#production_factory_start_efficiency_factor = -0.05	#can start production at 0 efficiency, nerf stat above further if needed
-				weekly_manpower = 100 #Silly, but better for small nations who need the raw MP
+				production_speed_buildings_factor = -0.05
+				industrial_capacity_dockyard = 0.05
+				industrial_capacity_factory = 0.05
+				army_core_attack_factor = -0.05
+				army_core_defence_factor = -0.05
+				research_speed_factor = 0.05
 				conscription_factor = 0.075
+				monthly_population = -0.05
+				stability_factor = -0.05
+				war_support_factor = 0.05
+				weekly_manpower = 100
 				#female_random_operative_chance = 3
 			}
 
@@ -214,12 +229,17 @@ ideas = {
 			}
 			
 			modifier = {
-				industrial_capacity_factory = -0.075
-				industrial_capacity_dockyard = -0.075
-				production_speed_facility_factor = 0.15
-				#production_factory_start_efficiency_factor = -0.10	#can start production at 0 efficiency, nerf stat above further if needed
-				conscription_factor = 0.15 #from 0.10, 0.15
-				weekly_manpower = 200 #Silly, but better for small nations who need the raw MP
+				production_speed_buildings_factor = -0.1
+				industrial_capacity_dockyard = 0.1
+				industrial_capacity_factory = 0.1
+				army_core_attack_factor = -0.1
+				army_core_defence_factor = -0.1
+				research_speed_factor = 0.1
+				conscription_factor = 0.15
+				monthly_population = -0.1
+				stability_factor = -0.1
+				war_support_factor = 0.1
+				weekly_manpower = 200
 				hidden_modifier = { #Needs to hide for non DLC plebs
 					female_random_operative_chance = 0.5
 					female_random_scientist_chance = 0.5


### PR DESCRIPTION
This was one of few things that personally bothered me a lot in R56. For such an important issue for it's time (considering women began gaining rights around 20th century on most countries), it's appaling to me that it was treated in R56 as a simple "do you want manpower or construction buff?" instead of serious changes it carried IRL. We're talking about entire parties winning/losing elections because women had vastly different preferences compared to men, this is not something you simulate with "factory output" and "manpower".

Well, no more! Women's rights, should this merge accepted, actually matters now. Let me explain the logic behind the buffs and nerfs seperating all options in two:

"Inequality" Options buffs:

- Construction speed: Families need houses and houses don't build themselves, that means more construction workers because supply and demand. That obviously means more construction.
- Attack/Defense on Core territory: Men on front have wives and children to worry about and they're gonna fight hard to protect/liberate them
- Stability: Half of population is silenced, and other half is given their own personal "kingdoms" in form of family, making them less likely to riot and endanger their family.
- Monthly population: A lot of marriages are obviously gonna lead to more children.

"Equality" Options buffs:

- Factory/Dockyard output: As women is allowed to work, some of them are obviously going to work (duh). That increases the factory/dockyard output due to, wait, more workers!
- Research speed: Same as above
- War support: As less marriages happen, there are going to be men who is willing to fight because they don't have to worry about their non-existent family's future anymore. 
- Weekly manpower: We're allowing women to serve now! Some gotta take interest on that.

"Optional" modifiers to consider (not included in code because implications of modifiers in question and/or balancing reasons)

- Ideology support: A nation that believes in gender equality is less likely to demand ideologies like Fascism and will more likely to support more women-friendly ideologies like Democracy, and vice versa.
- PP gain: Even though a lot of us today thankfully accepted that women deserve same rights as men, that was not the case back in the day. The sentiment that "women's place is next to her husband" was (and arguably is today in certain countries) still popular, and it took A LOT effort to change it to today's (at least for modern countries) standards. That effort can be simulated as PP loss if "Equality" options are taken.
- Surrender limit: Same reasons as war support