### PR TITLE
Update dod_infantry.gfx

### DIFF
--- a/gfx/entities/dod_infantry.gfx
+++ b/gfx/entities/dod_infantry.gfx
@@ -152,6 +152,67 @@ pdxmesh = {
 
 
 	}
+
+	pdxmesh = {
+			name = "HUN_infantry_snow_rifle_mesh"
+			file = "gfx/models/units/HUN_infantry_snow.mesh"
+
+			animation = { id = "idle"			type = "GER_infantry_rifle_idle_animation" }
+			animation = { id = "attack"			type = "GER_infantry_rifle_attack_animation" }
+			animation = { id = "support_attack"	type = "GER_infantry_rifle_support_attack_animation" }
+			animation = { id = "charge_rifle"	type = "GER_infantry_rifle_charge_animation" }
+			animation = { id = "charge_rifle_shoot"	type = "GER_infantry_rifle_charge_shoot_animation" }
+			animation = { id = "move"			type = "GER_infantry_rifle_moving_animation" }
+			animation = { id = "march_move"		type = "DOD_infantry_rifle_march_animation" }
+			animation = { id = "retreat"		type = "GER_infantry_rifle_retreat_animation" }
+			animation = { id = "death"			type = "GER_infantry_rifle_death_animation" }
+			animation = { id = "long_idle01"	type = "GER_infantry_rifle_long_idle_01_animation" }
+			animation = { id = "long_idle02"	type = "GER_infantry_rifle_long_idle_02_animation" }
+			animation = { id = "long_idle03"	type = "GER_infantry_rifle_long_idle_03_animation" }
+			animation = { id = "long_idle04"	type = "GER_infantry_rifle_long_idle_04_animation" }
+			animation = { id = "long_idle05"	type = "GER_infantry_rifle_long_idle_05_animation" }
+			animation = { id = "cavalry_idle"	type = "GER_infantry_cavalry_rider_rifle_idle_animation" }
+			animation = { id = "cavalry_move"	type = "GER_infantry_cavalry_rider_rifle_moving_animation" }
+			animation = { id = "training"		type = "GER_infantry_idle_training_animation" }
+			animation = { id = "jumping_jacks"	type = "GER_infantry_jumping_jacks_animation" }
+			animation = { id = "pushup"			type = "GER_infantry_pushup_animation" }
+			animation = { id = "guard_rifle"	type = "GER_infantry_guard_rifle_animation" }
+			animation = { id = "aim_exercise"	type = "GER_infantry_aim_exercise_animation" }
+
+			#scale = 1.1
+
+		}
+		
+	pdxmesh = {
+			name = "HUN_infantry_snow_mg_mesh"
+			file = "gfx/models/units/HUN_infantry_snow.mesh"
+
+			animation = { id = "idle"			type = "GER_infantry_mg_idle_animation" }
+			animation = { id = "attack"			type = "GER_infantry_mg_attack_animation" }
+			animation = { id = "support_attack"	type = "GER_infantry_mg_support_attack_animation" }
+			animation = { id = "charge_mg"		type = "GER_infantry_mg_charge_animation" }
+			animation = { id = "charge_mg_shoot"	type = "GER_infantry_mg_charge_shoot_animation" }
+			animation = { id = "move"			type = "GER_infantry_mg_moving_animation" }
+			animation = { id = "march_move"		type = "DOD_infantry_mg_march_animation" }
+			animation = { id = "retreat"		type = "GER_infantry_mg_retreat_animation" }
+			animation = { id = "death"			type = "GER_infantry_mg_death_animation" }
+			animation = { id = "long_idle01"	type = "GER_infantry_mg_long_idle_01_animation" }
+			animation = { id = "long_idle02"	type = "GER_infantry_mg_long_idle_02_animation" }
+			animation = { id = "long_idle03"	type = "GER_infantry_mg_long_idle_03_animation" }
+			animation = { id = "long_idle04"	type = "GER_infantry_mg_long_idle_04_animation" }
+			animation = { id = "long_idle05"	type = "GER_infantry_mg_long_idle_05_animation" }
+			animation = { id = "cavalry_idle"	type = "GER_infantry_cavalry_rider_mg_idle_animation" }
+			animation = { id = "cavalry_move"	type = "GER_infantry_cavalry_rider_mg_moving_animation" }
+			animation = { id = "training"		type = "GER_infantry_idle_training_animation" }
+			animation = { id = "jumping_jacks"	type = "GER_infantry_jumping_jacks_animation" }
+			animation = { id = "pushup"			type = "GER_infantry_pushup_animation" }
+			animation = { id = "guard_rifle"	type = "GER_infantry_guard_rifle_animation" }
+			animation = { id = "aim_exercise"	type = "GER_infantry_aim_exercise_mg_animation" }
+
+			#scale = 1.1
+
+
+		}
 	
 	pdxmesh = {
 		name = "HUN_infantry_weapon_mg_mesh"


### PR DESCRIPTION
added 2 missing vanilla mesh definitions that were being overwritten, causing these 3 errors:

`[01:53:29][no_game_date][pdx_entity.cpp:2070]: Couldn't find mesh "HUN_infantry_snow_rifle_mesh" (or HUN_infantry_snow_rifle_mesh is not of 'pdxmesh' type) [HUN_infantry_entity_snow] [01:53:29][no_game_date][pdx_entity.cpp:2070]: Couldn't find mesh "HUN_infantry_snow_mg_mesh" (or HUN_infantry_snow_mg_mesh is not of 'pdxmesh' type) [HUN_infantry_2_entity_snow] [01:53:29][no_game_date][pdx_entity.cpp:2070]: Couldn't find mesh "HUN_infantry_snow_rifle_mesh" (or HUN_infantry_snow_rifle_mesh is not of 'pdxmesh' type) [HUN_vehicle_infantry_rifle_entity_snow] `