### PR TITLE
Italy Fixes February 2025

### DIFF
--- a/common/national_focus/italy.txt
+++ b/common/national_focus/italy.txt
@@ -3857,7 +3857,7 @@ focus_tree = {
 		relative_position_id = ITA_fiocchi_munizioni
 		cost = 5
 		available = {
-			has_tech = radio_detection
+			is_special_project_completed = sp:sp_air_radar
 			has_full_control_of_state = 159
 		}
 
@@ -4673,12 +4673,15 @@ focus_tree = {
 
 				if = {
 					limit = {
-						has_tech = tech_engineers2
+						is_special_project_completed = sp:sp_land_flamethrower_tank
 					}
 					#L3/35 lf Flamethrower
 					ITA_add_basic_light_flamethrower_template = yes
 				}
 				else = {
+					sp:sp_land_flamethrower_tank = {
+						add_project_progress_ratio = 0.5
+					}
 					custom_effect_tooltip = ITA_italian_tankettes_flamethrower_tt
 					effect_tooltip = {
 						#L3/35 lf Flamethrower
@@ -6987,48 +6990,14 @@ focus_tree = {
 				uses = 1
 				category = ss_tech
 			}
-
+			
 			if = {
 				limit = {
-					has_dlc = "Man the Guns"
+					NOT = { is_special_project_completed = sp:sp_naval_cruiser_submarine }
 				}
-				set_technology = { cruiser_submarines = 1 }
-
-				create_equipment_variant = {
-					name = "Cagni Class"
-					type = ship_hull_cruiser_submarine
-					name_group = ITA_SS_HISTORICAL #TODO_Manu: Namelist
-					parent_version = 0
-					modules = {
-						fixed_ship_torpedo_slot = ship_torpedo_sub_1
-						fixed_ship_engine_slot = sub_ship_engine_2
-						front_1_custom_slot = ship_torpedo_sub_1
-						mid_1_custom_slot = empty
-						rear_1_custom_slot = ship_torpedo_sub_1
-					}
-				}
-				#Line Production
-				add_equipment_production = {
-					equipment = {
-						type = ship_hull_cruiser_submarine
-						creator = "ITA"
-						version_name = "Cagni Class"
-					}
-					name = "Ammiraglio Cagni"
-					requested_factories = 1
-					progress = 0.35
-					amount = 2
-				}
-				add_equipment_production = {
-					equipment = {
-						type = ship_hull_cruiser_submarine
-						creator = "ITA"
-						version_name = "Cagni Class"
-					}
-					name = "Ammiraglio Millo"
-					requested_factories = 1
-					progress = 0.35
-					amount = 2
+				complete_special_project = {
+					project = sp:sp_naval_cruiser_submarine
+					scientist = ITA_curio_bernardis
 				}
 			}
 			
@@ -10198,8 +10167,8 @@ focus_tree = {
 					add = il_duce_strengthen
 				}
 			}
-			custom_effect_tooltip = available_political_advisor
-			show_ideas_tooltip = ITA_pietro_koch
+			#custom_effect_tooltip = available_political_advisor
+			#show_ideas_tooltip = ITA_pietro_koch	- Waffle yoinked this guy from the history file, I am going to comment out references in game because it is spamming the error log.
 		}
 	}
 
@@ -15017,6 +14986,38 @@ focus_tree = {
 
 				ITA_add_the_king_of_the_skies_template_production_and_wing = yes
 			}
+
+			custom_effect_tooltip = generic_skip_one_line_tt
+
+			add_breakthrough_progress = {
+				specialization = specialization_air
+				value = 0.5
+			}
+
+			if = {
+				limit = {
+					has_dlc = "Gotterdammerung"
+				}
+				custom_effect_tooltip = ITA_modify_regia_aeronautica_dynamic_modifier_ns_intro
+				if = {
+					limit = {
+						NOT = { is_special_project_completed = sp_air_intercontinental_bomber }
+					}
+					add_to_variable = { 
+						ITA_ra_sp_air_intercontinental_bomber_speed_factor = 0.2
+						tooltip = sp_air_intercontinental_bomber_speed_factor_tt
+					}
+				}
+				if = {
+					limit = {
+						NOT = { is_special_project_completed = sp_air_mothership_aircraft }
+					}
+					add_to_variable = { 
+						ITA_ra_sp_air_mothership_aircraft_speed_factor = 0.2
+						tooltip = sp_air_mothership_aircraft_speed_factor_tt
+					}
+				}
+			}
 		}
 	}
 
@@ -15099,15 +15100,7 @@ focus_tree = {
 		relative_position_id = ITA_all_roads_lead_to_rome
 		cost = 5
 		available = {
-			if = {
-				limit = {
-					has_dlc = "Man the Guns"
-				}
-				has_tech = ship_hull_super_heavy
-			}
-			else = {
-				has_tech = heavy_battleship
-			}
+			is_special_project_completed = sp:sp_naval_super_heavy_battleship
 		}
 
 		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH}

--- a/localisation/english/ITA_l_english.yml
+++ b/localisation/english/ITA_l_english.yml
@@ -578,7 +578,7 @@
  ITA_develop_southern_shipyards_desc:0 "To meet our new needs in terms of naval production, we must expand our marine production capacities. We can extend the southern shipyards to meet our needs."
  ITA_naval_guerilla:0 "Naval Guerilla"
  ITA_naval_guerilla_desc:0 "Faced with navies much larger than ours, we must resort to more vicious tactics, using smaller maritime formations to harass enemy ships with light and rapid engagements."
- ITA_shift_toward_an_offensive_force:0 "Shift toward an Offensive Force"
+ ITA_shift_toward_an_offensive_force:0 "Shift Toward an Offensive Force"
  ITA_shift_toward_an_offensive_force_desc:0 "We must be able to strike first to make up for our inferiority in numbers."
  ITA_royal_intervention:0 "Royal Intervention"
  ITA_royal_intervention_desc:0 "We cannot trust the fascist regime to lead Italy toward glory. The setbacks we experienced in the early stages of our war in Ethiopia were a clear sign of the National Fascist Party's inability to lead. We need to oust the fascists and place the country under the control of our great King!"


### PR DESCRIPTION
I would just put this on the February bugfix branch, but this should probably get a lookover before it gets merged, as I do not work with ITA files and I am not certain of some intended choices.

Fixes:

1: Special project changes from vanilla were not properly ported over. This led to the focus ITA_caligulas_pride always being unavailable since GVD.

2: Fixes one capitalization bug

3: Comments out ITA_pietro_koch from the Italian focus tree. Waffle commented him out of the history file, so him being here is spamming our error log. I am going to assume the intended behavior is that the advisor is supposed to be gone from focus tree references.