### PR TITLE
Making BRA Integrate SA-country decisions work as they do in vanilla

### DIFF
--- a/events/TOA_Brazil.txt
+++ b/events/TOA_Brazil.txt
@@ -3165,6 +3165,14 @@ country_event = {
 		ai_chance = {
 			base = 1
 		}
+		FROM = {
+			every_owned_state = {
+				limit = {
+					is_core_of = PREV
+				}
+				add_core_of = ROOT
+			}
+		}
 		annex_country = {
 			target = FROM
 			transfer_troops = yes


### PR DESCRIPTION
(Re?)adds the cores to the United States of South America decisions, to make them function as they do in vanilla.

I don't know if it was intentionally removed, because the coring was never commented out, but this commit just adds it back. It is a cause for occasional bug reports, and no developer has responded to state that it was done intentionally, so I am going to throw it in this PR so I can get a second opinion before merging.

Reports:
https://discord.com/channels/337306241149960193/1327733889921454221/1348774227628785748
https://discord.com/channels/337306241149960193/337306241149960193/1314292308719435828

