### PR TITLE
Small Portugal Changes 

### DIFF
--- a/common/decisions/r56_POR_decisions.txt
+++ b/common/decisions/r56_POR_decisions.txt
@@ -717,6 +717,9 @@ POR_towards_a_greater_portugal = {
 				}
 				country_event = portugal.61	
 			}
+			custom_effect_tooltip = CHL_skip_one_line_tt
+			unlock_decision_tooltip = POR_proclaim_the_fifth_empire
+			unlock_decision_tooltip = POR_integrate_the_brazilian_administration
 		}
 	}
 	POR_proclaim_the_fifth_empire = {
@@ -1465,6 +1468,7 @@ POR_our_path_to_economic_development = {
 		days_remove = 120
 		modifier = {
 			industrial_capacity_factory = 0.15
+			industrial_capacity_dockyard = 0.15
 			production_factory_efficiency_gain_factor = 0.15
 		}
 		remove_effect = {
@@ -1842,6 +1846,7 @@ POR_together_against_salazar = {
 			neutrality_drift = -0.03
 			production_speed_buildings_factor = -0.25
 			industrial_capacity_factory = -0.25
+			industrial_capacity_dockyard = -0.25
 		}
 	}
 

--- a/common/ideas/r56_portugal.txt
+++ b/common/ideas/r56_portugal.txt
@@ -43,6 +43,7 @@ ideas = {
 				economy_cost_factor = 0.5
 				production_speed_buildings_factor = -0.15
 				industrial_capacity_factory = -0.15
+				industrial_capacity_dockyard = -0.15
 			}
 		}
 
@@ -555,6 +556,7 @@ ideas = {
 				democratic_drift = 0.01 
 				stability_factor = 0.03
 				industrial_capacity_factory = 0.05
+				industrial_capacity_dockyard = 0.05
 				production_factory_max_efficiency_factor = 0.15
 			}
 		}
@@ -568,6 +570,7 @@ ideas = {
 				political_power_factor = -0.15
 				stability_factor = 0.03
 				industrial_capacity_factory = 0.05
+				industrial_capacity_dockyard = 0.05
 				production_factory_max_efficiency_factor = 0.15
 				communism_drift = 0.01
 				global_building_slots_factor = 0.1
@@ -583,6 +586,7 @@ ideas = {
 				political_power_factor = -0.2
 				stability_factor = 0.05
 				industrial_capacity_factory = 0.05
+				industrial_capacity_dockyard = 0.05
 				production_factory_max_efficiency_factor = 0.15
 				democratic_drift = 0.01
 				global_building_slots_factor = 0.1
@@ -762,6 +766,7 @@ ideas = {
 				economy_cost_factor = 0.5
 				production_speed_buildings_factor = -0.15
 				industrial_capacity_factory = -0.15
+				industrial_capacity_dockyard = -0.15
 			}
 		}
 
@@ -777,6 +782,7 @@ ideas = {
 				neutrality_drift = 0.01
 				production_speed_buildings_factor = -0.05
 				industrial_capacity_factory = -0.05
+				industrial_capacity_dockyard = -0.05
 				trade_laws_cost_factor = 0.5
 				economy_cost_factor = 0.5
 			}
@@ -791,6 +797,7 @@ ideas = {
 			removal_cost = -1
 			modifier = {
 				industrial_capacity_factory = 0.05
+				industrial_capacity_dockyard = 0.05
 				global_building_slots_factor = 0.1
 			}
 		}
@@ -802,6 +809,7 @@ ideas = {
 			removal_cost = -1
 			modifier = {	
 				industrial_capacity_factory = 0.15
+				industrial_capacity_dockyard = 0.15
 				global_building_slots_factor = 0.1
 				production_speed_buildings_factor = 0.05
 			}
@@ -818,6 +826,7 @@ ideas = {
 				stability_factor = 0.05
 				neutrality_drift = 0.01
 				industrial_capacity_factory = 0.1
+				industrial_capacity_dockyard = 0.1
 				global_building_slots_factor = 0.1
 				trade_laws_cost_factor = 0.5
 				economy_cost_factor = 0.5
@@ -848,6 +857,7 @@ ideas = {
 				neutrality_drift = 0.02
 				production_speed_buildings_factor = 0.15
 				industrial_capacity_factory = 0.05
+				industrial_capacity_dockyard = 0.05
 			}
 		}
 
@@ -948,6 +958,7 @@ ideas = {
 				economy_cost_factor = 0.5
 				production_speed_buildings_factor = -0.2
 				industrial_capacity_factory = -0.2
+				industrial_capacity_dockyard = -0.2
 				fascism_drift = -0.02
 			}
 		}
@@ -963,6 +974,7 @@ ideas = {
 				economy_cost_factor = 0.25
 				production_speed_buildings_factor = -0.2
 				industrial_capacity_factory = -0.2
+				industrial_capacity_dockyard = -0.2
 				fascism_drift = -0.01
 			}
 		}
@@ -978,6 +990,7 @@ ideas = {
 				economy_cost_factor = 0.25
 				production_speed_buildings_factor = -0.2
 				industrial_capacity_factory = -0.2
+				industrial_capacity_dockyard = -0.2
 			}
 		}
 
@@ -991,6 +1004,7 @@ ideas = {
 				political_power_gain = 0.1
 				production_speed_buildings_factor = -0.1
 				industrial_capacity_factory = -0.1
+				industrial_capacity_dockyard = -0.1
 			}
 		}
 
@@ -1065,6 +1079,7 @@ ideas = {
 				political_power_gain = 0.1
 				production_factory_max_efficiency_factor = 0.08
 				industrial_capacity_factory = 0.04
+				industrial_capacity_dockyard = 0.04
 			}
 			research_bonus = { industry = 0.05 }
 		}
@@ -1080,6 +1095,7 @@ ideas = {
 				political_power_gain = 0.1
 				production_factory_max_efficiency_factor = 0.12
 				industrial_capacity_factory = 0.04
+				industrial_capacity_dockyard = 0.04
 			}
 			research_bonus = { industry = 0.05 }
 		}
@@ -1095,6 +1111,7 @@ ideas = {
 				political_power_gain = 0.2
 				production_factory_max_efficiency_factor = 0.15
 				industrial_capacity_factory = 0.05
+				industrial_capacity_dockyard = 0.05
 			}
 			research_bonus = { industry = 0.1 }
 		}

--- a/common/national_focus/r56_portugal.txt
+++ b/common/national_focus/r56_portugal.txt
@@ -3907,6 +3907,34 @@ focus_tree = {
 		available = { is_subject = no }
 		will_lead_to_war_with = ITA
 		will_lead_to_war_with = GER
+		bypass = { 
+			any_other_country = {
+				is_major = yes
+				has_war_with = ROOT
+				has_government = fascism
+			}
+		}
+		bypass_effect = {
+			add_war_support = 0.1
+			add_popularity = {
+				ideology = ROOT
+				popularity = 0.1
+			}
+			custom_effect_tooltip = CHL_skip_one_line_tt
+			every_country = {
+				limit = {
+					capital_scope = { is_on_continent = europe }
+					has_government = fascism
+				}
+				ROOT = {
+					create_wargoal = {
+						type = puppet_wargoal_focus
+						target = PREV
+						expire = 0
+					}
+				}
+			}
+		}
 		completion_reward = {
 			add_war_support = 0.05
 			custom_effect_tooltip = CHL_skip_one_line_tt
@@ -5017,6 +5045,36 @@ focus_tree = {
 					BRA = { is_in_faction_with = POR }
 				}
 			}
+		}
+		bypass = { 
+			500 = {
+				owner = {
+					OR = {
+						original_tag = ROOT
+						is_subject_of = ROOT
+					}
+				}
+			}
+		}
+		bypass_effect = {
+			add_political_power = 100
+			add_war_support = 0.1
+			add_popularity = {
+				ideology = ROOT
+				popularity = 0.1
+			}
+			custom_effect_tooltip = CHL_skip_one_line_tt
+			set_cosmetic_tag = KPB_kingdom_portugal_and_brazil
+			random_country = {
+				limit = {
+					original_tag = BRA
+					is_subject_of = ROOT
+				}
+				country_event = portugal.61	
+			}
+			custom_effect_tooltip = CHL_skip_one_line_tt
+			unlock_decision_tooltip = POR_proclaim_the_fifth_empire
+			unlock_decision_tooltip = POR_integrate_the_brazilian_administration
 		}
 		will_lead_to_war_with = BRA
 		completion_reward = {


### PR DESCRIPTION
- Added decision unlock tooltips to content that unlocks the **Proclaim the Fifth Empire** and **Integrate the Brazilian Administration** decisions ... which may otherwise go unnoticed by the player.
- Every decision modifier and idea that gives or reduces factory output now gives or reduces the same % in dockyard output. This should be a slight buff to naval builds, which I don't want to discourage.
- Added bypass conditions and effects for **Join the Global Fight Against Fascism** and **Avenge the 1821 Disaster**