### PR TITLE
Commie Honduras can actually survive now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-
-.vscode/settings.json
-.vscode/spellright.dict
-descriptor.mod

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 .vscode/settings.json
 .vscode/spellright.dict
+descriptor.mod

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+.vscode/settings.json
+.vscode/spellright.dict

--- a/common/national_focus/honduras.txt
+++ b/common/national_focus/honduras.txt
@@ -2618,9 +2618,8 @@ focus_tree = {
 		}
 		completion_reward = {
 			add_war_support = 0.10
-			USA = {
-				diplomatic_relation = { country = HON relation = guarantee active = no }
-			}
+			clr_country_flag = monroe_doctrine	
+			remove_ideas = USA_monroe_doctrine_idea	
 		}
 	}
 	
@@ -2682,6 +2681,8 @@ focus_tree = {
 				}
 				add_core_of = ROOT
 			}
+			GUA = {clr_country_flag = monroe_doctrine 
+			remove_ideas = USA_monroe_doctrine_idea}
 			custom_effect_tooltip = generic_skip_one_line_tt
 			unlock_decision_tooltip = { decision = HON_borderwar_with_belize_communist }
 			declare_war_on = {
@@ -2743,6 +2744,8 @@ focus_tree = {
 		
 		completion_reward = {
 			317 = { add_core_of = HON }
+			NIC = {clr_country_flag = monroe_doctrine 
+			remove_ideas = USA_monroe_doctrine_idea}
 			custom_effect_tooltip = generic_skip_one_line_tt
 			declare_war_on = {
 				target = NIC
@@ -2802,6 +2805,8 @@ focus_tree = {
 		
 		completion_reward = {
 			314 = { add_core_of = HON }
+			ELS = {clr_country_flag = monroe_doctrine 
+			remove_ideas = USA_monroe_doctrine_idea}
 			custom_effect_tooltip = generic_skip_one_line_tt
 			declare_war_on = {
 				target = ELS
@@ -2862,6 +2867,8 @@ focus_tree = {
 		
 		completion_reward = {
 			316 = { add_core_of = HON }
+			COS = {clr_country_flag = monroe_doctrine 
+			remove_ideas = USA_monroe_doctrine_idea}
 			custom_effect_tooltip = generic_skip_one_line_tt
 			declare_war_on = {
 				target = COS
@@ -2939,6 +2946,8 @@ focus_tree = {
 				}
 				add_core_of = ROOT
 			}
+			PAN = {clr_country_flag = monroe_doctrine 
+			remove_ideas = USA_monroe_doctrine_idea}
 			custom_effect_tooltip = generic_skip_one_line_tt
 			unlock_decision_tooltip = { decision = HON_borderwar_with_canal_communist }
 			declare_war_on = {


### PR DESCRIPTION
Communist path of Honduras doesn't account for new Monroe Doctrine changes unlike Fascist and Spanish paths, now conquering Central America focuses properly remove Monroe Doctrine from Honduras and target countries.

Notes: I intentionally didn't touch on conquering focuses after forming own alliance/joining Comintern as I imagine US wouldn't be too happy about it (even though Fascist and Spanish paths remove Monroe Doctrine from all conquering focuses.)