### PR TITLE
Fix non-MtG branches for UK showing

### DIFF
--- a/common/national_focus/uk.txt
+++ b/common/national_focus/uk.txt
@@ -10579,6 +10579,7 @@ focus_tree = {
 		}
 
 		allow_branch = {
+			always = no
 			if = {
 				limit = {
 					has_game_rule = {
@@ -16579,6 +16580,7 @@ focus_tree = {
 		}
 
 		allow_branch = {
+			always = no
 			if = {
 				limit = {
 					has_game_rule = {
@@ -17487,6 +17489,7 @@ focus_tree = {
 			focus = ENG_opposition_to_the_national_government
 		}
 		allow_branch = {
+			always = no
 			has_dlc = "La Resistance"
 			if = {
 				limit = {


### PR DESCRIPTION
MtG DLC checks were cleaned up but the checks for not having MtG here should've been replaced with always = no.
Currently the DLC and non-DLC versions overlap.