### PR TITLE
Biccy May Beta

### DIFF
--- a/common/national_focus/r56_turkey.txt
+++ b/common/national_focus/r56_turkey.txt
@@ -4791,7 +4791,7 @@ focus_tree = {
 		completion_reward = {
 			create_wargoal = {
 				target = IRQ
-				type = take_state_focus
+				type = puppet_wargoal_focus
 				expire = 0
 			}
 		}

--- a/common/national_focus/r56_turkey.txt
+++ b/common/national_focus/r56_turkey.txt
@@ -1542,10 +1542,8 @@ focus_tree = {
 	focus = {
 		id = TUR_found_an_air_war_academy
 		icon = GFX_goal_generic_air_doctrine
-		prerequisite = { focus = TUR_continue_the_military_reorganization }
 
 		x = -15
-		y = 1
 		relative_position_id = TUR_continue_the_military_reorganization
 		cost = 5
 
@@ -1888,12 +1886,8 @@ focus_tree = {
 	focus = {
 		id = TUR_continue_the_naval_expansion
 		icon = GFX_goal_generic_build_navy
-		prerequisite = { 
-			focus = TUR_continue_the_military_reorganization 
-		}
 
 		x = -7
-		y = 1
 		relative_position_id = TUR_continue_the_military_reorganization
 		cost = 5
 
@@ -1918,7 +1912,7 @@ focus_tree = {
 		x = -4
 		y = 1
 		relative_position_id = TUR_continue_the_naval_expansion
-		cost = 10
+		cost = 8
 
 		ai_will_do = {
 			factor = 10
@@ -2009,7 +2003,7 @@ focus_tree = {
 		y = 1
 		relative_position_id = TUR_continue_the_naval_expansion
 		
-		cost = 10
+		cost = 8
 
 		ai_will_do = {
 			factor = 10
@@ -2381,7 +2375,7 @@ focus_tree = {
 		x = 54
 		y = 0
 		offset = {
-			x = -32
+			x = -31
 			y = 0
 			trigger = {
 				has_game_rule = {
@@ -2882,8 +2876,8 @@ focus_tree = {
 		icon = GFX_goal_AFG_the_constitution_question
 		prerequisite = { focus = TUR_accomplishing_ataturks_dream }
 
-		x = -2
-		y = 1
+		x = -1
+		y = 2
 		relative_position_id = TUR_accomplishing_ataturks_dream
 		cost = 5
 
@@ -3272,8 +3266,8 @@ focus_tree = {
 		y = 1
 
 		offset = {
-			x = -21
-			y = 0
+			x = -22
+			y = 1
 			trigger = {
 				has_game_rule = {
 					rule = obsolete_focus_branches_visibility
@@ -3426,7 +3420,7 @@ focus_tree = {
 		y = 1
 
 		offset = {
-			x = -21
+			x = -23
 			y = 0
 			trigger = {
 				has_game_rule = {
@@ -4135,6 +4129,8 @@ focus_tree = {
 				}
 			}
 			custom_effect_tooltip = r56_newline
+			custom_effect_tooltip = TUR_the_ratio_of_units_under_our_command_will_depend_on_democratic_support_r56_tt
+			custom_effect_tooltip = generic_skip_one_line_tt
 			custom_effect_tooltip = available_political_advisor
 			show_ideas_tooltip = TUR_nuri_killigil
 			show_ideas_tooltip = TUR_riza_nur
@@ -4759,8 +4755,8 @@ focus_tree = {
 		id = TUR_pragmatic_expansionism
 		icon = GFX_goal_generic_foreign_diplomacy
 		prerequisite = { focus = TUR_western_detente }
-		x = 2
-		y = 1
+		x = 1
+		y = 2
 		relative_position_id = TUR_western_detente
 		cost = 10
 		ai_will_do = {
@@ -4774,10 +4770,38 @@ focus_tree = {
 	}
 
 	focus = {
+		id = TUR_end_the_southern_threat_r56
+		icon = GFX_focus_IRQ_party_of_national_brotherhood
+		prerequisite = { focus = TUR_western_detente }
+		x = 3
+		y = 2
+		relative_position_id = TUR_western_detente
+		cost = 6
+		ai_will_do = { base = 1 }
+		available = {
+			IRQ = {
+				OR = {
+					has_government = fascism
+					has_government = communism
+				}
+				NOT = { is_ally_with = ROOT }
+			}
+		}
+		will_lead_to_war_with = IRQ
+		completion_reward = {
+			create_wargoal = {
+				target = IRQ
+				type = take_state_focus
+				expire = 0
+			}
+		}
+	}
+
+	focus = {
 		id = TUR_liberalize_the_economy
 		icon = GFX_goal_free_trade
 		prerequisite = { focus = TUR_western_detente }
-		x = 4
+		x = 2
 		y = 1
 		relative_position_id = TUR_western_detente
 		cost = 8
@@ -5211,8 +5235,14 @@ focus_tree = {
 
 		available = {
 			is_subject = no
-			NOT = {
-				has_completed_focus = TUR_western_detente
+			if = {
+				limit = { has_completed_focus = TUR_western_detente }
+				GRE = {
+					OR = {
+						has_government = communism
+						has_government = fascism
+					}
+				}
 			}
 		}
 	   
@@ -5644,12 +5674,45 @@ focus_tree = {
 	}
 
 	focus = {
+		id = TUR_improve_our_regional_influence_r56
+		icon = GFX_focus_spa_the_spanish_miracle
+		prerequisite = { focus = TUR_liberalize_the_national_economy }
+		prerequisite = { focus = TUR_amend_the_secular_policies }
+		x = 1
+		y = 1
+		relative_position_id = TUR_liberalize_the_national_economy
+		cost = 5
+		ai_will_do = {
+			factor = 7
+		}
+		available = {
+			NOT = {
+				has_completed_focus = TUR_wartime_rationing
+				threat > 0.5
+			}
+		}
+		completion_reward = {
+			add_ideas = TUR_arbiter_of_the_muslim_world_idea
+			if = {
+				limit = {
+					NOT = {
+						has_completed_focus = TUR_bicontinental_intervention
+					}
+				}
+				set_rule = { can_send_volunteers = yes }
+			}
+			set_rule = { can_guarantee_other_ideologies = yes }
+		}
+		search_filters = { FOCUS_FILTER_POLITICAL FOCUS_FILTER_TUR_TRADITIONALISM }
+	}
+
+	focus = {
 		id = TUR_specialization_led_development
 		icon = GFX_focus_hol_abandon_the_gold_standard
 		prerequisite = { focus = TUR_liberalize_the_national_economy }
 
 		x = 0
-		y = 1
+		y = 2
 		relative_position_id = TUR_liberalize_the_national_economy
 		cost = 12.9
 
@@ -5694,7 +5757,7 @@ focus_tree = {
 		icon = GFX_goal_free_trade
 		prerequisite = { focus = TUR_liberalize_the_national_economy }
 
-		x = -2
+		x = -1
 		y = 1
 		relative_position_id = TUR_liberalize_the_national_economy
 		cost = 5
@@ -5805,7 +5868,7 @@ focus_tree = {
 		prerequisite = { focus = TUR_amend_the_secular_policies }
 
 		x = 0
-		y = 1
+		y = 2
 		relative_position_id = TUR_amend_the_secular_policies
 		cost = 10
 
@@ -5858,7 +5921,7 @@ focus_tree = {
 		icon = GFX_goal_generic_madrasah_2_black_white
 		prerequisite = { focus = TUR_amend_the_secular_policies }
 
-		x = 2
+		x = 1
 		y = 1
 		relative_position_id = TUR_amend_the_secular_policies
 		cost = 10
@@ -6047,8 +6110,8 @@ focus_tree = {
 		icon = GFX_focus_generic_attack_kurdistan
 		prerequisite = { focus = TUR_lead_the_underground_komunist_partisi }
 
-		x = -4
-		y = 1
+		x = -3
+		y = 2
 		relative_position_id = TUR_lead_the_underground_komunist_partisi
 		cost = 5
 
@@ -7053,10 +7116,10 @@ focus_tree = {
 		id = TUR_the_montreux_convention_r56
 		icon = GFX_focus_TUR_the_montreux_convention
 		text = TUR_the_montreux_convention
-		x = 40
+		x = 39
 		y = 0
 		offset = {
-			x = 6
+			x = 8
 			y = 0
 			trigger = {
 				has_game_rule = {
@@ -7084,7 +7147,7 @@ focus_tree = {
 			}
 		}
 		offset = {
-			x = 17
+			x = 18
 			y = 0
 			trigger = {
 				has_game_rule = {
@@ -7095,7 +7158,7 @@ focus_tree = {
 			}
 		}
 		offset = {
-			x = 13
+			x = 16
 			y = 0
 			trigger = {
 				has_game_rule = {
@@ -7426,8 +7489,8 @@ focus_tree = {
 		cost = 5
 		prerequisite = { focus = TUR_neutrality_through_deterrence }
 		relative_position_id = TUR_the_montreux_convention_r56
-		x = -7
-		y = 2
+		x = -6
+		y = 3
 		offset = {
 			x = 3
 			y = 0

--- a/events/MUN_Czechoslovakia.txt
+++ b/events/MUN_Czechoslovakia.txt
@@ -2602,6 +2602,9 @@ country_event = { #Merging with Poland
 	is_triggered_only = yes
 
 	option = {
+		ai_chance = {
+			base = 6
+		}
 		name = MUN_czech.1031.a
 		hidden_effect = {
 			every_core_state = {
@@ -2618,6 +2621,15 @@ country_event = { #Merging with Poland
 		custom_effect_tooltip = GAME_OVER_TT
 	}
 	option = {
+		ai_chance = {
+			base = 4
+			modifier = {
+				add = -2
+				FROM = {
+					is_major = yes
+				}
+			}
+		}
 		name = MUN_czech.1031.b
 		set_variable = { global.CZE_origin_event = 1031 }	#used to decide loc
 		FROM = {
@@ -2952,6 +2964,9 @@ country_event = {
 					country_event = { id = MUN_the_fall_of_the_republic.3 days = 10 } #it keeps getting worse huh?
 				}
 			}
+			every_core_state = {
+				set_state_flag = CZE_restore_core
+			}
 		}
 	}
 
@@ -3182,6 +3197,21 @@ country_event = {
 			custom_effect_tooltip = generic_skip_one_line_tt
 
 			custom_effect_tooltip = MUN_czech.1034.c_tt
+		}
+	}
+
+	after = {
+		hidden_effect = {
+			every_state = {
+				limit = {
+					has_state_flag = CZE_restore_core
+					NOT = {
+						is_core_of = ROOT
+					}
+				}
+				add_core_of = ROOT
+				clr_state_flag = CZE_restore_core
+			}
 		}
 	}
 }
@@ -3743,6 +3773,19 @@ country_event = { #divided nation is over
 	picture = GFX_report_event_cze_divided_nation
 
 	is_triggered_only = yes
+
+	immediate = {
+		hidden_effect = {	#this is for if the very last decision was interrupted by releasing
+			if = {
+				limit = {
+					has_dynamic_modifier = {
+						modifier = CZE_a_divided_nation_dynamic_modifier
+					}
+				}
+				remove_dynamic_modifier = { modifier = CZE_a_divided_nation_dynamic_modifier }
+			}
+		}
+	}
 
 	option = { #good news
 		name = MUN_czech.1046.a
@@ -4482,6 +4525,14 @@ country_event = { #Now Ruthenian wants out
 
 	is_triggered_only = yes
 
+	immediate = {
+		hidden_effect = {
+			every_core_state = {
+				set_state_flag = CZE_restore_core
+			}
+		}
+	}
+
 	option = { #Okay
 		name = MUN_the_fall_of_the_republic.3.a
 		ai_chance = {
@@ -4640,6 +4691,21 @@ country_event = { #Now Ruthenian wants out
 				}
 			}
 			RUT = { change_tag_from = ROOT }
+		}
+	}
+
+	after = {
+		hidden_effect = {
+			every_state = {
+				limit = {
+					has_state_flag = CZE_restore_core
+					NOT = {
+						is_core_of = ROOT
+					}
+				}
+				add_core_of = ROOT
+				clr_state_flag = CZE_restore_core
+			}
 		}
 	}
 }

--- a/localisation/english/TUR_l_english.yml
+++ b/localisation/english/TUR_l_english.yml
@@ -84,13 +84,13 @@
  TUR_continue_the_push_for_autarky_desc:0 "The Ottoman Empire's economic dependence on foreign powers was a crucial weakness in its later, faltering years. A Turkey dependent solely on the Turkish people is our greatest path to continued independence from the western powers."
  
  TUR_expand_the_aegean_economic_heartland:0 "Expand the Aegean Economic Heartland"
- TUR_expand_the_aegean_economic_heartland_desc:0 "The aegean regions have long been the wealthiest part of Turkey. While not an original plan, further investments into their economy would bolster the nation as a whole."
+ TUR_expand_the_aegean_economic_heartland_desc:0 "The Aegean regions have long been the wealthiest part of Turkey. While not an original plan, further investments into their economy would bolster the nation as a whole."
  
  TUR_expand_the_bursa_textile_industry:0 "Expand the Bursa Textile Industry"
- TUR_expand_the_bursa_textile_industry_desc:0 "The aegean region of Bursa has amassed itself an impressive textile industry. As an essential good, we should further encourage Bursa textile developments."
+ TUR_expand_the_bursa_textile_industry_desc:0 "The Aegean region of Bursa has amassed itself an impressive textile industry. As an essential good, we should further encourage Bursa textile developments."
  
  TUR_expand_the_izmir_cement_industry:0 "Expand the Izmir Cement Industry"
- TUR_expand_the_izmir_cement_industry_desc:0 "The aegean region of Izmir has amassed itself a strong cement industry. We should further encourage cement developments to bolster the construction industry for all of the nation."
+ TUR_expand_the_izmir_cement_industry_desc:0 "The Aegean region of Izmir has amassed itself a strong cement industry. We should further encourage cement developments to bolster the construction industry for all of the nation."
  
  TUR_middle_east_institute_of_technology:0 "Middle East Institute of Technology"
  TUR_middle_east_institute_of_technology_desc:0 "The rapid industrialization of our nation has opened up new opportunities in R&D that we should pursue. With an advanced technical university in the heart of our land, we can conduct more research."
@@ -199,7 +199,7 @@
  TUR_renew_the_soviet_non_aggression_pact_focus_days_tt:0 "Has been 105 or more days since focus §YRenew the Soviet Non-Aggression Pact§! has been completed"
  TUR_renew_the_soviet_non_aggression_pact_current_days_tt:0 "Current days are: [?TUR_renew_the_soviet_non_aggression_pact_flag:days|Y0]"
  turkey.117.t:0 "Amending the Montreux Convention?"
- turkey.117.d:0 "[FROM.getAdjective] have approached us with a reconciling offer regarding the Montreux Convention signed not a few years ago. They offer to grant our troops free access to the country while we are expected to guard them from enemies of the people. \nHaving control over strategically important straits can give us the missing advantage in the Mediterranian to battle the imperialist ambitions of Great Powers in the region. What should the ultimate decision be?"
+ turkey.117.d:0 "[FROM.getAdjective] have approached us with a reconciling offer regarding the Montreux Convention signed not a few years ago. They offer to grant our troops free access to the country while we are expected to guard them from enemies of the people. \nHaving control over strategically important straits can give us the missing advantage in the Mediterranean to battle the imperialist ambitions of Great Powers in the region. What should the ultimate decision be?"
  turkey.117.a:0 "This initiative pleases us, we agree!"
  turkey.117.b:0 "The Turks think this will save them?"
  turkey.118.t:0 "The Soviets Agree"
@@ -262,7 +262,7 @@
  r56_TUR_offer_sulymaniyah_autonomy:0 "Offer Sulymaniyah Autonomy"
 
  TUR_liberate_the_peninsula:0 "Liberate the Peninsula"
- TUR_liberate_the_peninsula_desc:0 "The Arabian Peninsula is ruled by sick, tyranical puppet monarchs. We shall bring an end this vile tyranny!"
+ TUR_liberate_the_peninsula_desc:0 "The Arabian Peninsula is ruled by sick, tyrannical puppet monarchs. We shall bring an end this vile tyranny!"
 
  TUR_demand_french_withdrawal_from_syria:0 "Demand French Withdrawal From Syria"
  TUR_demand_french_withdrawal_from_syria_desc:0 "Ever since the end of the Great War, the French have formally held mandate over the historic Ottoman Syrian territory. Syrians, your liberation from the decadent French is near!"
@@ -296,14 +296,14 @@
  r56_TUR_alliance_with_romania:0 "Alliance with Romania"
  r56_TUR_alliance_with_yugoslavia:0 "Alliance with Yugoslavia"
  turkey.123.t:0 "Alliance with Turkey?"
- turkey.123.d:0 "The Turkish Foreign Minister has approached us with an offer of alliance between our nations, as part of their initiative moving towards pan-balkan cooperation. What should our responce be?"
+ turkey.123.d:0 "The Turkish Foreign Minister has approached us with an offer of alliance between our nations, as part of their initiative moving towards pan-Balkan cooperation. What should our response be?"
  turkey.123.a:0 "Of course. Further ties would be for the best"
  turkey.123.b:0 "No, the Turks are not to be trusted."
  turkey.124.t:0 "The [FROM.GetAdjective]'s Have Accepted"
- turkey.124.d:0 "The [FROM.GetAdjective] Foreign Minister has issued an official responce, stating their pleasing acceptance of an alliance."
+ turkey.124.d:0 "The [FROM.GetAdjective] Foreign Minister has issued an official response, stating their pleasing acceptance of an alliance."
  turkey.124.a:0 "We stand together."
  turkey.125.t:0 "The [FROM.GetAdjective]'s Have Declined"
- turkey.125.d:0 "The [FROM.GetAdjective] Foreign Minister has issued an official responce, stating their rejection to the idea of an alliance at this time."
+ turkey.125.d:0 "The [FROM.GetAdjective] Foreign Minister has issued an official response, stating their rejection to the idea of an alliance at this time."
  turkey.125.a:0 "Disappointing."
  
  TUR_militarize_the_saadabat_pact:0 "Militarize the Saadabad Pact"
@@ -354,10 +354,10 @@
  TUR_medium_bomber_focus_desc:0 "Western nations have led the way in bomber developments. We should import their designs to see what we may learn from them."
  
  TUR_protecting_our_way_of_life:0 "Protecting Our Way of Life"
- TUR_protecting_our_way_of_life_desc:0 "Anatolia is the home of our people, now and forever. Our airforce must serve to protect Turkey from any threat facing our nation."
+ TUR_protecting_our_way_of_life_desc:0 "Anatolia is the home of our people, now and forever. Our air force must serve to protect Turkey from any threat facing our nation."
 
  TUR_airland_battle:0 "Air-Land Battle"
- TUR_airland_battle_desc:0 "Close air support bombers have proven decisive in modern ground assaults. We should continue restructuring our airforce with air-land coordination as a backbone." 
+ TUR_airland_battle_desc:0 "Close air support bombers have proven decisive in modern ground assaults. We should continue restructuring our air force with air-land coordination as a backbone." 
  
  TUR_naval_bombers:0 "Auxiliaries for the Fleet"
  TUR_naval_bombers_desc:0 "Nations such as Italy have put strong focus into bombers that serve as auxiliary to their surface-fleet. This strategy seems highly adaptable to Turkey's circumstances, perhaps it's time we create naval bomber programs of our own."
@@ -387,12 +387,12 @@
  TUR_doctrine_on_western_lines_desc:0 "The Army of the Grand National Assembly has inspiration from the armed forces of many European nations, France and Germany in particular. Ankara will speed forward as Berlin and Paris too leap forward."
  
  TUR_defending_our_borders:0 "Defending Our Borders"
- TUR_defending_our_borders_desc:0 "While Turkey has a plethora of natural defenses, the extension of fortifications on the lines of foreign nations would be a wise strategy in further detering hostility."
+ TUR_defending_our_borders_desc:0 "While Turkey has a plethora of natural defenses, the extension of fortifications on the lines of foreign nations would be a wise strategy in further deterring hostility."
  
  TUR_expand_officer_schools:0 "Expand the Turkish Military Academy"
  TUR_expand_officer_schools_desc:0 "The Turkish Military Academy has guided many of our greatest officers. Its expansion would culminate in a new generation of a proficient, adaptable Turkish high command."
  
- TUR_mass_army:0 "Expand the Groundforce"
+ TUR_mass_army:0 "Expand the Ground Force"
  TUR_mass_army_desc:0 "The victories of Prussia in the 19th century, and France in the 20th have depended on heavy use of conscription. We should continue our army's expansion so that we may become a force on two continents to be feared."
 
  TUR_sharpen_troop_equipment:0 "Sharpen Troop Equipment"
@@ -462,7 +462,7 @@
  TUR_r56_the_path_of_the_wolf_desc:0 "Our economy is hardly in the position to produce a large surface fleet. A humble, cheap submarine-focused fleet is an affordable, effective method to get through a prolonged war with any of the regions naval powers."
 
  TUR_balanced_navy:0 "Leading Surface Fleet"
- TUR_balanced_navy_desc:0 "A fleet with a sole focus is vulnerable to enemy adaptation. Despite the higher cost, a maleable surface is necessary to hold our own in a prolonged war."
+ TUR_balanced_navy_desc:0 "A fleet with a sole focus is vulnerable to enemy adaptation. Despite the higher cost, a malleable surface is necessary to hold our own in a prolonged war."
  
  TUR_control_our_seas:0 "Control our Seas"
  TUR_control_our_seas_desc:0 "As a rapidly renewing power, we must push once more toward a dominant position throughout our waterways. A proud nation needs a proud navy to defend her interests."
@@ -560,7 +560,7 @@
  r56_TUR_hail_to_the_marshal_desc:0 "Fevzi Çakmak is the only man among our nation truly in the place to inherit Atatürk's mantle! This will shall be inscribed throughout all!"
 
  TUR_war_bonds:0 "War Bonds"
- TUR_war_bonds_desc:0 "Conflict is once more on its way. Even a blind man can see the danger in remaining unpreared. Collection efforts through volunteer-based war bonds would be an excellent way to kickstart our military's expansion!"
+ TUR_war_bonds_desc:0 "Conflict is once more on its way. Even a blind man can see the danger in remaining unprepared. Collection efforts through volunteer-based war bonds would be an excellent way to kickstart our military's expansion!"
  TUR_war_bonds_tt:0 "Unlocks decisions to renew §YNational Struggle Funds§! upon expiration."
  r56_TUR_renew_the_national_struggle_funds:0 "Renew the National Struggle Funds"
 
@@ -685,6 +685,9 @@
 
  TUR_liberalize_the_national_economy:0 "Liberalize the National Economy"
  TUR_liberalize_the_national_economy_desc:0 "The policy of etatism has served its purpose, and failed elsewhere. Private investment will guide the economy forward!"
+
+ TUR_improve_our_regional_influence_r56: "Improve our Regional Influence"
+ TUR_improve_our_regional_influence_r56_desc: "As a force of strength and democracy in both the Middle-East and Balkans, we are in position to guide as a soft power in the region. We shall be looked to as the nation who ties west and east together!"
  
  TUR_specialization_led_development:0 "Specialization-Led Development"
  TUR_specialization_led_development_desc:0 "Years of etatism, built through an uncanny mixture of the various economic systems, have not brought Turkey close enough to economic modernity. We shall steer the nation in a new economic direction, basing each regions economy off their own specialized industries."
@@ -696,13 +699,14 @@
  TUR_amend_the_secular_policies_desc:0 "The CHP's secular policies have gone too far, and violated any idea that they care for popular mandate. We shall lift the grip that they have over the nation at once!"
 
  TUR_peace_between_turks_and_kurds:0 "Peace Between Turks and Kurds"
- TUR_peace_between_turks_and_kurds_desc:0 "Much of the Turkish-Kurdish conflict has been fueled by the excess of contemptible secular policies. We shall end this conflict at once by bringing an end to the CHP's "progress" and unifying the nation under the guise of our muslim unity!"
+ TUR_peace_between_turks_and_kurds_desc:0 "Much of the Turkish-Kurdish conflict has been fueled by the excess of contemptible secular policies. We shall end this conflict at once by bringing an end to the CHP's "progress" and unifying the nation under the guise of our Muslim unity!"
 
  TUR_end_the_ban_on_the_arabic_adhan:0 "End the Ban on the Arabic Adhan"
  TUR_end_the_ban_on_the_arabic_adhan_desc:0 "The ban on the Arabic Adhan violates the principles of Islam, in which our people abide. These shall come to an end at once."
 
  TUR_overthrow_inonus_government:0 "Overthrow İnönü's Government"
  TUR_overthrow_inonus_government_desc:0 "The decadence of the CHP will no longer be tolerated. We shall officially launch our uprising against these traitors, and restore what was once!"
+ TUR_the_ratio_of_units_under_our_command_will_depend_on_democratic_support_r56_tt: "The ratio of units under our command will depend on §4Democratic§! support."
 
  TUR_stabilize_the_nation:0 "Stabilize the Nation"
  TUR_stabilize_the_nation_desc:0 "Now is finally the time to rebuild the things we once had, and guide the Turkish people past the horrors of the Republican government!"
@@ -736,7 +740,7 @@
  TUR_western_detente_desc:0 "The western nations are a necessary evil. Our future should depend on playing them against each other until we are strong enough to do otherwise."
 
  TUR_liberalize_the_economy:0 "Liberalize the Economy"
- TUR_liberalize_the_economy_desc:0 "The policies of heavy state intervention have left our economy sluggish. We should put a renewed focus on increasing trade ties, and privatizing vital sectors so that we can become the economic center of the muslim world!"
+ TUR_liberalize_the_economy_desc:0 "The policies of heavy state intervention have left our economy sluggish. We should put a renewed focus on increasing trade ties, and privatizing vital sectors so that we can become the economic center of the Muslim world!"
  TUR_liberal_economic_reforms_idea:0 "Liberal Economic Reforms"
 
  TUR_pragmatic_expansionism:0 "Pragmatic Expansionism"
@@ -748,7 +752,7 @@
  turkey.141.a:0 "We need all the friends we can get."
  turkey.141.b:0 "Syria's ours, despite what any occupiers say!"
  turkey.142.t:0 "The French Accept!"
- turkey.142.d:0 "Seeing it as inevitable, [FROM.getAdjective] diplomats have decided to not test their fate and have delieved a positive answer to our humble request. We shall move forward and occupy the disputed area immediately!"
+ turkey.142.d:0 "Seeing it as inevitable, [FROM.getAdjective] diplomats have decided to not test their fate and have delivered a positive answer to our humble request. We shall move forward and occupy the disputed area immediately!"
  turkey.142.a:0 "Mine, mine, it is all mine!"
  turkey.143.t:0 "The French Decline"
  turkey.143.d:0 "An official denunciation of our humble request was received at our embassy by our ambassador from their respective [FROM.getAdjective] counterparts. We might have to swallow the hard pill and perhaps accept the unthinkable. On the other hand, there is also a way to keep our dignity in this situation by means of aggressive diplomacy."
@@ -765,13 +769,16 @@
  turkey.146.d:0 "The British have unfortunately refused our offer to have Cyprus leased to us."
  turkey.146.a:0 "Disappointing."
 
+ TUR_end_the_southern_threat_r56: "End the Southern Threat"
+ TUR_end_the_southern_threat_r56_desc: "Recent developments in Baghdad have taken things too far and the time has come for us to act against it. In return for our armed support, surely the British can accept our control over these lands once more."
+
  TUR_restore_the_imperial_borders:0 "Restore the Imperial Borders"
  TUR_restore_the_imperial_borders_desc:0 "Our tragic, multi-century decline saw us lose our most critical territories. We must restore our reach, and become the power we were destined to be!"
 
  TUR_amicable_ties_across_the_middle_east:0 "Amicable Ties Across the Middle-East"
  TUR_amicable_ties_across_the_middle_east_desc:0 "Our fellow nations of the Middle-East need a true power to guide them. We shall give it to them."
  turkey.138.t:0 "The Ottoman Empire Offers Guarantees"
- turkey.138.d:0 "The Ottoman Foreign Minister has approached our own today, offering conditionless support against attacks by foreign powers, which has a clear, indirect meaning: The expansion of forceful British and Soviet influence throughout the region will not be tolerated. What are we to say to the shocking development from the Ottomans?"
+ turkey.138.d:0 "The Ottoman Foreign Minister has approached our own today, offering unconditional support against attacks by foreign powers, which has a clear, indirect meaning: The expansion of forceful British and Soviet influence throughout the region will not be tolerated. What are we to say to the shocking development from the Ottomans?"
  turkey.138.a:0 "Of course!"
  turkey.138.b:0 "What makes them think we need their help?"
  turkey.139.t:0 "The [FROM.GetAdjective]'s have accepted!"
@@ -786,7 +793,7 @@
  TUR_one_persian_ottoman_war_to_end_them_all_requirement_tt:0 "If §YRestore the Imperial Borders§! has not been completed:"
 
  TUR_arbiter_of_the_muslim_world:0 "Arbiter of the Muslim World"
- TUR_arbiter_of_the_muslim_world_desc:0 "The 19th century traumatized the Muslim world, as the nations around us fell to the whims of western powers. As the worlds *truly* free Muslim power, we must use our role as regional leader to safeguard the children of allah from the decadence and exploitation of western imperialism."
+ TUR_arbiter_of_the_muslim_world_desc:0 "The 19th century traumatized the Muslim world, as the nations around us fell to the whims of western powers. As the worlds *truly* free Muslim power, we must use our role as regional leader to safeguard the children of God from the decadence and exploitation of western imperialism."
  TUR_arbiter_of_the_muslim_world_idea:0 "Arbiter of the Muslim World"
 
  TUR_batum_and_the_muslim_caucasian_states:0 "Batum and the Muslim Caucasian States"
@@ -836,7 +843,7 @@
  TUR_claim_greater_bulgaria_tt:0 "Gains claim on all §YBulgarian§! and §YMacedonian§! states, and §YSouthern Dobruja§!"
 
  TUR_befriend_the_bulgarians:0 "Befriend the Bulgarians"
- TUR_befriend_the_bulgarians_desc:0 "The Bulgarians were one of the last nations to gain independence from our empire. We must come to terms with the reality that concrete hold over the balkans is an impossibility. The Ottoman and Bulgarian cause are the same, we shall work together to avenge our territorial losses!"
+ TUR_befriend_the_bulgarians_desc:0 "The Bulgarians were one of the last nations to gain independence from our empire. We must come to terms with the reality that concrete hold over the Balkans is an impossibility. The Ottoman and Bulgarian cause are the same, we shall work together to avenge our territorial losses!"
  turkey.132.t:0 "Secret Agreement with the Ottomans?"
  turkey.132.d:0 "The Ottoman Foreign Minister has met with our own in Sofia, proposing an offer regarding the Greek situation. The Ottomans would renounce any further territorial claims in the Balkans, and support our claim over the Thracian coastline. In return, they would like assistance in crushing the Greeks, to meet their own claims over the Aegean Islands, as well as Crete. What are we to say to their offer?"
  turkey.132.a:0 "For the glory of our nations, we shall both receive what's rightfully ours!"
@@ -852,7 +859,7 @@
  turkey.135.a:0 "Friendly ties are in our interests!"
  turkey.135.b:0 "These fools think this will stop us?"
  turkey.136.t:0 "The Bulgarians Agree!"
- turkey.136.d:0 "The Bulgarians have accepted our offer for a non-aggression pact. May the world recognize our commitment toward peace on the balkan peninsula!"
+ turkey.136.d:0 "The Bulgarians have accepted our offer for a non-aggression pact. May the world recognize our commitment toward peace on the Balkan peninsula!"
  turkey.136.a:0 "To a brighter future!"
  turkey.137.t:0 "The Bulgarians have Refused"
  turkey.137.d:0 "The Bulgarians have refused. What interest do they possibly have in souring relations with our reborn nation?"
@@ -1040,7 +1047,7 @@
  turkey.102.a:0 "From the British? Unheard of."
 
  turkey.104.t:0 "Turkey Requests Guarantees"
- turkey.104.d:0 "Stranding two continents, and neighboured my great powers, Turkey has found itself in a strategically vital, but dangerous geographical situation. Recently Turkish diplomats have approached us with a request for guarantees against any threats potentially made against them. In return they offer us their friendship."
+ turkey.104.d:0 "Stranding two continents, and neighbored my great powers, Turkey has found itself in a strategically vital, but dangerous geographical situation. Recently Turkish diplomats have approached us with a request for guarantees against any threats potentially made against them. In return they offer us their friendship."
  turkey.104.a:0 "We must help Turkey stay out of any conflict."
  turkey.104.b:0 "We have other ideas for Turkey."
 
@@ -1110,7 +1117,7 @@
  turkey.14.a:0 "To the new Turkey!"
 
  turkey.15.t:0 "Turkish Communists Request Aid"
- turkey.15.d:0 "Members of the Turkish Communist Party have come to Moscow requesting aid in a planned uprising against the government. While they believe their plan to be full proof, they are requesting guarantees of arms and military support to help the Turkish workers tear down their oppressive government.\n\nRegardless of their plans, having a loyal communist state on our southern border will be useful for our national defence."
+ turkey.15.d:0 "Members of the Turkish Communist Party have come to Moscow requesting aid in a planned uprising against the government. While they believe their plan to be full proof, they are requesting guarantees of arms and military support to help the Turkish workers tear down their oppressive government.\n\nRegardless of their plans, having a loyal communist state on our southern border will be useful for our national defense."
  turkey.15.a:0 "We shall support our Turkish Friends."
  turkey.15.b:0 "Those Turks are on their own."
 
@@ -1122,7 +1129,7 @@
  turkey.17.d:0 "Sadly our representatives have returned from the Soviet Union empty handed. It appears that the Soviets, while sympathetic to our plight, have no desire to offer us assistance in the uprising against our government."
  turkey.17.a:0 "But why?"
 
- turkey.20.t:0 "Turkey Demands Decolonisation"
+ turkey.20.t:0 "Turkey Demands Decolonization"
  turkey.20.d:0 "Representatives of the Turkish government have come to us with an ultimatum. Either we withdraw from all territories in the Middle East, or we will face a war of liberation.\n\nAt first they were laughed out, but it appears that Turkey is quite serious and seeks to free the Middle East from foreign rule."
  turkey.20.a:0 "It is in our best interests to let the people be free."
  turkey.20.b:0 "We will not give up the middle east to the Turks."
@@ -1149,10 +1156,10 @@
  TUR_the_balkan_pact:0 "The Balkan Pact"
  TUR_the_balkan_pact_desc:0 "The Balkans are home to many powerful nations that can be our friends. We should reach out to them."
  TUR_join_with_romania:0 "Join with Romania"
- TUR_join_with_romania_desc:0 "Romania is a powerful potential ally. We should seek to unite ourselves in defence of the Balkans."
+ TUR_join_with_romania_desc:0 "Romania is a powerful potential ally. We should seek to unite ourselves in defense of the Balkans."
  TUR_reconcile_with_greece:0 "Reconcile with Greece"
  TUR_reconcile_with_greece_desc:0 "Greece has long been our rival and enemy. But perhaps we can now be friends."
- TUR_solidify_the_saadabad_pact:0 "Militarise the Saadabad Pact"
+ TUR_solidify_the_saadabad_pact:0 "Militarize the Saadabad Pact"
  TUR_solidify_the_saadabad_pact_desc:0 "We have many friends across the Middle East. We shall seek to make our Saadabad Pact a true alliance."
  TUR_a_city_of_spies:0 "A City of Spies"
  TUR_a_city_of_spies_desc:0 "At the bar of hotels, at the terrasses of the cafes, along the shores of the Bosporus. Everywhere in the city foreigners are meeting, documents and rumors are exchanged. Shady characters are exchanging documents. Some diplomatic briefcases may even hide bombs..."
@@ -1176,7 +1183,7 @@
 #  TUR_hilmi_uran:0 "Hilmi Uran" # Minister of Justice & later Minister of Internal Affairs # same as vanilla
  TUR_fuat_agrali:0 "Fuat Ağralı" # Minister of Finance
 
- TUR_reaffirm_balkan_hegemony:0 "Reafirm Balkan Hegemony"
+ TUR_reaffirm_balkan_hegemony:0 "Reaffirm Balkan Hegemony"
  TUR_reaffirm_balkan_hegemony_desc:0 "The people of the Balkans use to fear us. They will bow to the Sublime Porte once again."
  TUR_revanchism_focus:0 "Revanchism"
 
@@ -1199,7 +1206,7 @@
  bftb_turkey.144.a:0 "We must protect our Turkish interests."
  bftb_turkey.144.b:0 "We could not keep such a promise."
  bftb_turkey.145.t:0 "[From.GetNameDefCap] Provides Guarantee"
- bftb_turkey.145.d:0 "[From.GetNameDefCap] has realised our strategic importance and has agreed to guarantee our sovereignty."
+ bftb_turkey.145.d:0 "[From.GetNameDefCap] has realized our strategic importance and has agreed to guarantee our sovereignty."
  bftb_turkey.145.a:0 "This will keep our enemies at bay."
  bftb_turkey.146.t:0 "[From.GetNameDefCap] Refuses to Guarantee Our Freedom"
  bftb_turkey.146.d:0 "[From.GetNameDefCap] has decided not to guarantee us, seeing it as too risky in the current world situation."
@@ -1247,7 +1254,7 @@
  TUR_the_true_muslim_unity_desc:0 "Only the unity the Ummah will guarantee our success."
 
  TUR_institutional_reorganization:0 "Institutional Reorganization"
- TUR_institutional_reorganization_desc:0 "The government has to be reorganised in order to align with our ideological objectives."
+ TUR_institutional_reorganization_desc:0 "The government has to be reorganized in order to align with our ideological objectives."
 
  TUR_black_sea_swindle:0 "Black Sea Swindle"
  TUR_black_sea_swindle_desc:0 "Our enemies will be chased far away from our sea."


### PR DESCRIPTION
Road to 56 Turkey Focus Tree:
- Fixed many typos
- Small qol/layout improvements.
- Gave the Ottoman civil war focus a tooltip explaining that its size is based on democratic support.
- Allowed the pro-west Ottoman path to annex Greece via focus if they go fascist/communist.
- Added a focus for the pro-west Ottoman path to annex Iraq, if they go fascist/communist.
- Added a focus for the conservative-democratic path giving them the ability to send volunteers.