### PR TITLE
Sicilian political advisors

### DIFF
--- a/common/characters/SCI.txt
+++ b/common/characters/SCI.txt
@@ -67,4 +67,85 @@ characters={
 			logistics_skill = 2	
 		}
 	}
+
+	SCI_vittorio_emanuele_orlando={
+		name = SCI_vittorio_emanuele_orlando
+		portraits={
+			civilian={
+				small = "GFX_idea_generic_political_advisor_european_1"
+			}
+		}
+		advisor={
+			slot = political_advisor
+			idea_token = SCI_vittorio_emanuele_orlando
+			allowed = {
+				original_tag = SCI
+			}
+			traits = { smooth_talking_charmer }
+			cost = 150
+			ai_will_do = {
+				factor = 1.000
+			}
+		}
+	}
+	SCI_vincenzo_florio={
+		name = SCI_vincenzo_florio
+		portraits={
+			civilian={
+				small = "GFX_idea_generic_political_advisor_european_2"
+			}
+		}
+		advisor={
+			slot = political_advisor
+			idea_token = SCI_vincenzo_florio
+			allowed = {
+				original_tag = SCI
+			}
+			traits = { captain_of_industry }
+			cost = 150
+			ai_will_do = {
+				factor = 1.000
+			}
+		}
+	}
+	SCI_luigi_lavitrano={
+		name = SCI_luigi_lavitrano
+		portraits={
+			civilian={
+				small = "GFX_idea_generic_political_advisor_european_3"
+			}
+		}
+		advisor={
+			slot = political_advisor
+			idea_token = SCI_luigi_lavitrano
+			allowed = {
+				original_tag = SCI
+			}
+			traits = { compassionate_gentleman }
+			cost = 150
+			ai_will_do = {
+				factor = 1.000
+			}
+		}
+	}
+	SCI_vincenzo_giuffrida={
+		name = SCI_vincenzo_giuffrida
+		portraits={
+			civilian={
+				small = "GFX_idea_generic_political_advisor_european_4"
+			}
+		}
+		advisor={
+			slot = political_advisor
+			idea_token = SCI_vincenzo_giuffrida
+			allowed = {
+				original_tag = SCI
+			}
+			traits = { financial_expert }
+			cost = 150
+			ai_will_do = {
+				factor = 1.000
+			}
+		}
+	}
 }


### PR DESCRIPTION
Add four Sicilian political advisors

- Vittorio Emanuele Orlando (smooth_talking_charmer)
- Vincenzo Florio Jr. (captain_of_industry)
- Cardinal Luigi Lavitrano (compassionate_gentleman)
- Vincenzo Giuffrida (financial_expert)

## TODO
- [ ] Localization entries in SCI_l_english.yml
- [ ] Custom DDS portraits if available

- [ ] Optional: ideology-gated `available` blocks