### PR TITLE
Fix two NS for ROC:KMT_three_year_plan and KMT_army_of_a_bygone_era

### DIFF
--- a/common/ideas/r56_china.txt
+++ b/common/ideas/r56_china.txt
@@ -1240,6 +1240,9 @@ ideas = {
 					has_idea = KMT_nanjing_decade_2
 					has_idea = KMT_nanjing_decade_3
 					has_idea = KMT_nanjing_decade_4
+					has_idea = KMT_nanjing_decade_2_b
+					has_idea = KMT_nanjing_decade_3_b
+					has_idea = KMT_nanjing_decade_4_b
 				}
 			}
 			on_remove = {
@@ -1724,7 +1727,7 @@ ideas = {
 			}
 			
 			modifier = {
-				army_attack_factor = -0.9
+				army_attack_factor = -0.09
 				army_defence_factor = -0.18
 				conscription_factor = -0.18
 				army_morale_factor = -0.18


### PR DESCRIPTION
I added validation conditions for the existence of "KMT_three_year_plan": According to the national focus files, besides the four existing types of "KMT_three_year_plan", there are three additional types of "KMT_three_year_planb".

Additionally, I fixed a decimal point error regarding the attack modifier in "KMT_army_of_a_bygone_era_9".