### PR TITLE
Fix SPD tag for Republican Spain

### DIFF
--- a/common/country_tag_aliases/tag_aliases.txt
+++ b/common/country_tag_aliases/tag_aliases.txt
@@ -62,7 +62,10 @@ SPC = {
 
 SPD = {
 	original_tag = SPR
-	has_country_flag = SPR_republican_spain_flag
+	OR = {
+		has_country_flag = SPR_republican_spain_flag
+		has_country_flag = scw_no_lar_republicans
+	}
 }
 
 VIC = {

--- a/events/Spain.txt
+++ b/events/Spain.txt
@@ -197,7 +197,6 @@ country_event = {
 				set_country_flag = scw_no_lar_republicans
 				set_country_flag = sided_with_the_republicans_spanish_civil_war_flag	
 				set_country_flag = r56_i_am_the_spr_start_up_and_bypass
-				set_country_flag = SPR_republican_spain_flag
 				remove_ideas = SPR_the_black_years
 				remove_ideas = SPR_r56_strike_first
 				add_ideas = SPR_r56_non_intervention_agreement

--- a/events/Spain.txt
+++ b/events/Spain.txt
@@ -197,6 +197,7 @@ country_event = {
 				set_country_flag = scw_no_lar_republicans
 				set_country_flag = sided_with_the_republicans_spanish_civil_war_flag	
 				set_country_flag = r56_i_am_the_spr_start_up_and_bypass
+				set_country_flag = SPR_republican_spain_flag
 				remove_ideas = SPR_the_black_years
 				remove_ideas = SPR_r56_strike_first
 				add_ideas = SPR_r56_non_intervention_agreement


### PR DESCRIPTION
I met this issue when playing as SOV and enabled r56 focus for Spain.
In the current version, the Soviet Union cannot send volunteers to Republican Spain because its country tag is only "D08" instead of "SPD". After checking and comparing with the vanilla game, I found that the issue is caused by the missing country flag for the Republicans in the code.
By adding the flag the game can now correctly add SPD as an alias tag for D08 (the Republican Spain)