### PR TITLE
excavation tech AI's tendency BUG

### DIFF
--- a/common/technologies/industry.txt
+++ b/common/technologies/industry.txt
@@ -1936,7 +1936,7 @@ technologies = {
 		}
 		
 		ai_will_do = {
-			factor = 0
+			factor = 1
 			
 			modifier = {
 				factor = 1
@@ -2023,7 +2023,7 @@ technologies = {
 		}
 		
 		ai_will_do = {
-			factor = 0
+			factor = 1
 			
 			modifier = {
 				factor = 1
@@ -2110,7 +2110,7 @@ technologies = {
 		}
 		
 		ai_will_do = {
-			factor = 0
+			factor = 1
 			
 			modifier = {
 				factor = 1.0
@@ -2192,7 +2192,7 @@ technologies = {
 		}
 		
 		ai_will_do = {
-			factor = 0
+			factor = 1
 			
 			modifier = {
 				factor = 1.0

--- a/common/technologies/industry.txt
+++ b/common/technologies/industry.txt
@@ -1848,10 +1848,10 @@ technologies = {
 		}
 		
 		ai_will_do = {
-			factor = 0
+			base = 0
 			modifier = {
 
-				factor = 5.0
+				add = 5.0
 				OR = {
 					oil > 0
 					aluminium > 0
@@ -1936,12 +1936,11 @@ technologies = {
 		}
 		
 		ai_will_do = {
-			factor = 1
+			base = 0
 			
 			modifier = {
-				factor = 1
+				add = 1
 				OR = {
-
 					oil > 0
 					aluminium > 0
 					rubber > 0
@@ -2023,10 +2022,10 @@ technologies = {
 		}
 		
 		ai_will_do = {
-			factor = 1
+			base = 0
 			
 			modifier = {
-				factor = 1
+				add = 1
 				OR = {
 
 					oil > 0
@@ -2110,10 +2109,10 @@ technologies = {
 		}
 		
 		ai_will_do = {
-			factor = 1
+			base = 0
 			
 			modifier = {
-				factor = 1.0
+				add = 1
 				OR = {
 
 					oil > 0
@@ -2192,10 +2191,10 @@ technologies = {
 		}
 		
 		ai_will_do = {
-			factor = 1
+			base = 0
 			
 			modifier = {
-				factor = 1.0
+				add = 1
 				OR = {
 
 					oil > 0


### PR DESCRIPTION
There is an issue with the AI research weights for the Excavation technologies, specifically the extra ones added by RT56. The AI factor is set to 0, which causes the AI to completely ignore late-game excavation techs. Since it's set to 0, it's impossible for the AI to ever pick these techs. I believe this is a bug/oversight because there are still modifiers attached to them.