### PR TITLE
Fix stuck MEFO Bills 100% CG penalty after swapping economy NS

### DIFF
--- a/common/scripted_effects/GER_scripted_effects.txt
+++ b/common/scripted_effects/GER_scripted_effects.txt
@@ -1265,6 +1265,7 @@ GER_stop_rearmament = {
 			has_dynamic_modifier = { modifier = GER_mefo_bills_modifier }
 		}
 		hidden_effect = { #The rearmament program has cost Germany dearly
+			GER_clear_mefo_bills_penalty = yes #The 100% CGFF penalty must go with the MEFO Bills, otherwise it sticks forever on the Recovering Economy
 			remove_dynamic_modifier = { modifier = GER_mefo_bills_modifier }
 			add_dynamic_modifier = { modifier = GER_recovering_economy_modifier }
 			set_variable = { #Reset CG to 0 so that you don't suffer doubly when paying back the MEFO Bills
@@ -1341,6 +1342,7 @@ GER_stop_rearmament = {
 			has_dynamic_modifier = { modifier = GER_economy_of_conquest_modifier }
 		}
 		hidden_effect = { #The rearmament program has cost Germany dearly
+			GER_clear_mefo_bills_penalty = yes #The 100% CGFF penalty must go with the Economy of Conquest, otherwise it sticks forever on the Recovering Economy
 			remove_dynamic_modifier = { modifier = GER_economy_of_conquest_modifier }
 			add_dynamic_modifier = { modifier = GER_recovering_economy_modifier }
 			set_variable = { #Reset CG to 0 so that you don't suffer doubly when paying back the MEFO Bills
@@ -1397,6 +1399,15 @@ GER_reduce_mefo_bills_penalty = {
 			has_country_flag = GER_mefo_bills_penalty_flag
 			check_variable = { GER_industrial_consumer_goods_factor < 1 }
 		}
+		GER_clear_mefo_bills_penalty = yes
+	}
+}
+
+GER_clear_mefo_bills_penalty = { #Removes the 100% CGFF penalty no matter the current CG value. Used when the MEFO Bills/Economy of Conquest NS is swapped out, since the monthly fail-safe in on_actions only runs while one of those two NS is active
+	if = {
+		limit = {
+			has_country_flag = GER_mefo_bills_penalty_flag
+		}
 		clr_country_flag = GER_mefo_bills_penalty_flag
 		subtract_from_variable = { GER_industrial_consumer_goods_expected_value = GER_expected_consumer_goods_penalty }
 		add_to_variable = { GER_industrial_industrial_capacity_factory = GER_factory_output_penalty }
@@ -1410,6 +1421,7 @@ GER_autarky_achieved_effects = {
 			has_dynamic_modifier = { modifier = GER_mefo_bills_modifier }
 		}
 		hidden_effect = {
+			GER_clear_mefo_bills_penalty = yes #The 100% CGFF penalty must go with the MEFO Bills, otherwise it sticks forever on the Wirtschaftswunder
 			remove_dynamic_modifier = { modifier = GER_mefo_bills_modifier }
 			add_dynamic_modifier = { modifier = GER_wirtschaftswunder_modifier }
 		}
@@ -1436,6 +1448,7 @@ GER_autarky_achieved_effects = {
 			has_dynamic_modifier = { modifier = GER_economy_of_conquest_modifier }
 		}
 		hidden_effect = {
+			GER_clear_mefo_bills_penalty = yes #The 100% CGFF penalty must go with the Economy of Conquest, otherwise it sticks forever on the Wirtschaftswunder
 			remove_dynamic_modifier = { modifier = GER_economy_of_conquest_modifier }
 			add_dynamic_modifier = { modifier = GER_wirtschaftswunder_modifier }
 		}
@@ -1446,6 +1459,7 @@ GER_autarky_achieved_effects = {
 			has_dynamic_modifier = { modifier = GER_recovering_economy_modifier }
 		}
 		hidden_effect = {
+			GER_clear_mefo_bills_penalty = yes #Fail-safe for old saves where the penalty was left over by an earlier NS swap
 			remove_dynamic_modifier = { modifier = GER_recovering_economy_modifier }
 			add_dynamic_modifier = { modifier = GER_wirtschaftswunder_modifier }
 		}


### PR DESCRIPTION
The 100% consumer goods penalty (GER_mefo_bills_penalty_flag: -20% factory output, -20% dockyard output, +10% expected CG) was only ever cleared by GER_reduce_mefo_bills_penalty, which the monthly on_action only calls while GER_mefo_bills_modifier or GER_economy_of_conquest_modifier is active.

Achieve Autarky (and Prioritize Economic Growth) swap that NS for the Wirtschaftswunder / Recovering Economy, which read the exact same GER_industrial_* variables, so the penalty stayed applied permanently with no way left to remove it.

Add GER_clear_mefo_bills_penalty, which removes the penalty regardless of the current CG value, and call it in every NS swap. GER_reduce_mefo_bills_penalty now delegates to it, keeping its CG < 1 condition for the monthly fail-safe.